### PR TITLE
Use ligo binary from $PATH if available

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,16 +1,16 @@
 {
-  "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.43.3",
-  "packages": [
-    "taqueria-protocol",
-    "taqueria-lib*",
-    "taqueria-plugin*",
-    "taqueria-sdk",
-    "taqueria-toolkit",
-    "taqueria-analytics",
-    "taqueria-vscode*",
-    "tests",
-    "."
-  ],
-  "useNx": false
+	"$schema": "node_modules/lerna/schemas/lerna-schema.json",
+	"version": "0.43.3",
+	"packages": [
+		"taqueria-protocol",
+		"taqueria-lib*",
+		"taqueria-plugin*",
+		"taqueria-sdk",
+		"taqueria-toolkit",
+		"taqueria-analytics",
+		"taqueria-vscode*",
+		"tests",
+		"."
+	],
+	"useNx": false
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,16 +1,16 @@
 {
-	"$schema": "node_modules/lerna/schemas/lerna-schema.json",
-	"version": "0.43.3",
-	"packages": [
-		"taqueria-protocol",
-		"taqueria-lib*",
-		"taqueria-plugin*",
-		"taqueria-sdk",
-		"taqueria-toolkit",
-		"taqueria-analytics",
-		"taqueria-vscode*",
-		"tests",
-		"."
-	],
-	"useNx": false
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+  "version": "0.43.4",
+  "packages": [
+    "taqueria-protocol",
+    "taqueria-lib*",
+    "taqueria-plugin*",
+    "taqueria-sdk",
+    "taqueria-toolkit",
+    "taqueria-analytics",
+    "taqueria-vscode*",
+    "tests",
+    "."
+  ],
+  "useNx": false
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.43.4",
+  "version": "0.43.5",
   "packages": [
     "taqueria-protocol",
     "taqueria-lib*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@taqueria/root",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@taqueria/root",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"workspaces": [
 				"./taqueria-protocol",
@@ -19865,10 +19865,10 @@
 		},
 		"taqueria-analytics": {
 			"name": "@taqueria/analytics",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/protocol": "^0.43.3",
+				"@taqueria/protocol": "^0.43.4",
 				"node-machine-id-xz": "^1.0.2"
 			},
 			"devDependencies": {
@@ -19878,10 +19878,10 @@
 		},
 		"taqueria-lib-ligo": {
 			"name": "@taqueria/lib-ligo",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -19891,10 +19891,10 @@
 		},
 		"taqueria-plugin-archetype": {
 			"name": "@taqueria/plugin-archetype",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
 				"fast-glob": "^3.3.1",
 				"ts-pattern": "^5.0.5"
 			},
@@ -19905,10 +19905,10 @@
 		},
 		"taqueria-plugin-contract-types": {
 			"name": "@taqueria/plugin-contract-types",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "ISC",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
 				"@taquito/michel-codec": "^18.0.0-RC.0",
 				"@taquito/signer": "^18.0.0-RC.0",
 				"@taquito/taquito": "^18.0.0-RC.0",
@@ -20069,10 +20069,10 @@
 		},
 		"taqueria-plugin-core": {
 			"name": "@taqueria/plugin-core",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3"
+				"@taqueria/node-sdk": "^0.43.4"
 			},
 			"devDependencies": {
 				"tsup": "^7.2.0",
@@ -20084,11 +20084,11 @@
 		},
 		"taqueria-plugin-flextesa": {
 			"name": "@taqueria/plugin-flextesa",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3",
-				"@taqueria/protocol": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/protocol": "^0.43.4",
 				"async-retry": "^1.3.3",
 				"bignumber.js": "^9.1.2",
 				"fast-glob": "^3.2.12",
@@ -20103,7 +20103,7 @@
 		},
 		"taqueria-plugin-helloworld": {
 			"name": "@taqueria/plugin-helloworld",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@taqueria/node-sdk": "0.41.0"
@@ -20323,11 +20323,11 @@
 		},
 		"taqueria-plugin-ipfs-pinata": {
 			"name": "@taqueria/plugin-ipfs-pinata",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@helia/unixfs": "^1.4.2",
-				"@taqueria/node-sdk": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
 				"dotenv": "^16.3.1",
 				"form-data": "^4.0.0",
 				"helia": "^2.0.3",
@@ -20341,11 +20341,11 @@
 		},
 		"taqueria-plugin-jest": {
 			"name": "@taqueria/plugin-jest",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3",
-				"@taqueria/plugin-contract-types": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/plugin-contract-types": "^0.43.4",
 				"@taquito/signer": "^18.0.0-RC.0",
 				"@taquito/taquito": "^18.0.0-RC.0",
 				"@taquito/utils": "^18.0.0-RC.0",
@@ -20566,11 +20566,11 @@
 		},
 		"taqueria-plugin-ligo": {
 			"name": "@taqueria/plugin-ligo",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/lib-ligo": "^0.43.3",
-				"@taqueria/node-sdk": "^0.43.3",
+				"@taqueria/lib-ligo": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.4",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -20580,11 +20580,11 @@
 		},
 		"taqueria-plugin-ligo-legacy": {
 			"name": "@taqueria/plugin-ligo-legacy",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/lib-ligo": "^0.43.3",
-				"@taqueria/node-sdk": "^0.43.3",
+				"@taqueria/lib-ligo": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.4",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -20594,11 +20594,11 @@
 		},
 		"taqueria-plugin-metadata": {
 			"name": "@taqueria/plugin-metadata",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3",
-				"@taqueria/protocol": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/protocol": "^0.43.4",
 				"prompts": "^2.4.2"
 			},
 			"devDependencies": {
@@ -20609,18 +20609,18 @@
 		},
 		"taqueria-plugin-mock": {
 			"name": "@taqueria/plugin-mock",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3"
+				"@taqueria/node-sdk": "^0.43.4"
 			}
 		},
 		"taqueria-plugin-octez-client": {
 			"name": "@taqueria/plugin-octez-client",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -20633,10 +20633,10 @@
 		},
 		"taqueria-plugin-smartpy": {
 			"name": "@taqueria/plugin-smartpy",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -20649,10 +20649,10 @@
 		},
 		"taqueria-plugin-smartpy-legacy": {
 			"name": "@taqueria/plugin-smartpy-legacy",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -20665,10 +20665,10 @@
 		},
 		"taqueria-plugin-taquito": {
 			"name": "@taqueria/plugin-taquito",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.3",
+				"@taqueria/node-sdk": "^0.43.4",
 				"@taquito/michel-codec": "^18.0.0-RC.0",
 				"@taquito/signer": "^18.0.0-RC.0",
 				"@taquito/taquito": "^18.0.0-RC.0",
@@ -20762,7 +20762,7 @@
 		},
 		"taqueria-protocol": {
 			"name": "@taqueria/protocol",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@peculiar/webcrypto": "^1.4.3",
@@ -20786,10 +20786,10 @@
 		},
 		"taqueria-sdk": {
 			"name": "@taqueria/node-sdk",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/protocol": "^0.43.3",
+				"@taqueria/protocol": "^0.43.4",
 				"@taquito/signer": "^17.3.1",
 				"@taquito/taquito": "^17.3.1",
 				"@taquito/utils": "^17.3.1",
@@ -20991,10 +20991,10 @@
 		},
 		"taqueria-toolkit": {
 			"name": "@taqueria/toolkit",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/protocol": "^0.43.3",
+				"@taqueria/protocol": "^0.43.4",
 				"buffer": "^6.0.3",
 				"cross-spawn": "^7.0.3",
 				"yargs": "^17.7.2"
@@ -21045,12 +21045,12 @@
 		},
 		"taqueria-vscode-extension": {
 			"name": "taqueria",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@microsoft/signalr": "^6.0.18",
-				"@taqueria/analytics": "^0.43.3",
-				"@taqueria/protocol": "^0.43.3",
+				"@taqueria/analytics": "^0.43.4",
+				"@taqueria/protocol": "^0.43.4",
 				"cli-table3": "^0.6.3",
 				"comment-json": "^4.2.3",
 				"eventsource": "^2.0.2",
@@ -21082,7 +21082,7 @@
 			}
 		},
 		"taqueria-vscode-extension-web-ui": {
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"dependencies": {
 				"@taquito/michel-codec": "^17.3.1",
 				"@taquito/michelson-encoder": "^17.3.1",
@@ -21219,7 +21219,7 @@
 		},
 		"tests": {
 			"name": "@taqueria/tests",
-			"version": "0.43.3",
+			"version": "0.43.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@gmrchk/cli-testing-library": "^0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@taqueria/root",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@taqueria/root",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"workspaces": [
 				"./taqueria-protocol",
@@ -19865,10 +19865,10 @@
 		},
 		"taqueria-analytics": {
 			"name": "@taqueria/analytics",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/protocol": "^0.43.4",
+				"@taqueria/protocol": "^0.43.5",
 				"node-machine-id-xz": "^1.0.2"
 			},
 			"devDependencies": {
@@ -19878,10 +19878,10 @@
 		},
 		"taqueria-lib-ligo": {
 			"name": "@taqueria/lib-ligo",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -19891,10 +19891,10 @@
 		},
 		"taqueria-plugin-archetype": {
 			"name": "@taqueria/plugin-archetype",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
 				"fast-glob": "^3.3.1",
 				"ts-pattern": "^5.0.5"
 			},
@@ -19905,10 +19905,10 @@
 		},
 		"taqueria-plugin-contract-types": {
 			"name": "@taqueria/plugin-contract-types",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "ISC",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
 				"@taquito/michel-codec": "^18.0.0-RC.0",
 				"@taquito/signer": "^18.0.0-RC.0",
 				"@taquito/taquito": "^18.0.0-RC.0",
@@ -20069,10 +20069,10 @@
 		},
 		"taqueria-plugin-core": {
 			"name": "@taqueria/plugin-core",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4"
+				"@taqueria/node-sdk": "^0.43.5"
 			},
 			"devDependencies": {
 				"tsup": "^7.2.0",
@@ -20084,11 +20084,11 @@
 		},
 		"taqueria-plugin-flextesa": {
 			"name": "@taqueria/plugin-flextesa",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4",
-				"@taqueria/protocol": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
+				"@taqueria/protocol": "^0.43.5",
 				"async-retry": "^1.3.3",
 				"bignumber.js": "^9.1.2",
 				"fast-glob": "^3.2.12",
@@ -20103,7 +20103,7 @@
 		},
 		"taqueria-plugin-helloworld": {
 			"name": "@taqueria/plugin-helloworld",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@taqueria/node-sdk": "0.41.0"
@@ -20323,11 +20323,11 @@
 		},
 		"taqueria-plugin-ipfs-pinata": {
 			"name": "@taqueria/plugin-ipfs-pinata",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@helia/unixfs": "^1.4.2",
-				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
 				"dotenv": "^16.3.1",
 				"form-data": "^4.0.0",
 				"helia": "^2.0.3",
@@ -20341,11 +20341,11 @@
 		},
 		"taqueria-plugin-jest": {
 			"name": "@taqueria/plugin-jest",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4",
-				"@taqueria/plugin-contract-types": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
+				"@taqueria/plugin-contract-types": "^0.43.5",
 				"@taquito/signer": "^18.0.0-RC.0",
 				"@taquito/taquito": "^18.0.0-RC.0",
 				"@taquito/utils": "^18.0.0-RC.0",
@@ -20566,11 +20566,11 @@
 		},
 		"taqueria-plugin-ligo": {
 			"name": "@taqueria/plugin-ligo",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/lib-ligo": "^0.43.4",
-				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/lib-ligo": "^0.43.5",
+				"@taqueria/node-sdk": "^0.43.5",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -20580,11 +20580,11 @@
 		},
 		"taqueria-plugin-ligo-legacy": {
 			"name": "@taqueria/plugin-ligo-legacy",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/lib-ligo": "^0.43.4",
-				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/lib-ligo": "^0.43.5",
+				"@taqueria/node-sdk": "^0.43.5",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -20594,11 +20594,11 @@
 		},
 		"taqueria-plugin-metadata": {
 			"name": "@taqueria/plugin-metadata",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4",
-				"@taqueria/protocol": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
+				"@taqueria/protocol": "^0.43.5",
 				"prompts": "^2.4.2"
 			},
 			"devDependencies": {
@@ -20609,18 +20609,18 @@
 		},
 		"taqueria-plugin-mock": {
 			"name": "@taqueria/plugin-mock",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4"
+				"@taqueria/node-sdk": "^0.43.5"
 			}
 		},
 		"taqueria-plugin-octez-client": {
 			"name": "@taqueria/plugin-octez-client",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -20633,10 +20633,10 @@
 		},
 		"taqueria-plugin-smartpy": {
 			"name": "@taqueria/plugin-smartpy",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -20649,10 +20649,10 @@
 		},
 		"taqueria-plugin-smartpy-legacy": {
 			"name": "@taqueria/plugin-smartpy-legacy",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
 				"fast-glob": "^3.3.1"
 			},
 			"devDependencies": {
@@ -20665,10 +20665,10 @@
 		},
 		"taqueria-plugin-taquito": {
 			"name": "@taqueria/plugin-taquito",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.43.4",
+				"@taqueria/node-sdk": "^0.43.5",
 				"@taquito/michel-codec": "^18.0.0-RC.0",
 				"@taquito/signer": "^18.0.0-RC.0",
 				"@taquito/taquito": "^18.0.0-RC.0",
@@ -20762,7 +20762,7 @@
 		},
 		"taqueria-protocol": {
 			"name": "@taqueria/protocol",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@peculiar/webcrypto": "^1.4.3",
@@ -20786,10 +20786,10 @@
 		},
 		"taqueria-sdk": {
 			"name": "@taqueria/node-sdk",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/protocol": "^0.43.4",
+				"@taqueria/protocol": "^0.43.5",
 				"@taquito/signer": "^17.3.1",
 				"@taquito/taquito": "^17.3.1",
 				"@taquito/utils": "^17.3.1",
@@ -20991,10 +20991,10 @@
 		},
 		"taqueria-toolkit": {
 			"name": "@taqueria/toolkit",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/protocol": "^0.43.4",
+				"@taqueria/protocol": "^0.43.5",
 				"buffer": "^6.0.3",
 				"cross-spawn": "^7.0.3",
 				"yargs": "^17.7.2"
@@ -21045,12 +21045,12 @@
 		},
 		"taqueria-vscode-extension": {
 			"name": "taqueria",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@microsoft/signalr": "^6.0.18",
-				"@taqueria/analytics": "^0.43.4",
-				"@taqueria/protocol": "^0.43.4",
+				"@taqueria/analytics": "^0.43.5",
+				"@taqueria/protocol": "^0.43.5",
 				"cli-table3": "^0.6.3",
 				"comment-json": "^4.2.3",
 				"eventsource": "^2.0.2",
@@ -21082,7 +21082,7 @@
 			}
 		},
 		"taqueria-vscode-extension-web-ui": {
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"dependencies": {
 				"@taquito/michel-codec": "^17.3.1",
 				"@taquito/michelson-encoder": "^17.3.1",
@@ -21219,7 +21219,7 @@
 		},
 		"tests": {
 			"name": "@taqueria/tests",
-			"version": "0.43.4",
+			"version": "0.43.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@gmrchk/cli-testing-library": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/root",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "An easy to use opinionated tool for building, testing, and deploying Tezos software",
 	"main": "index.ts",
 	"directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/root",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "An easy to use opinionated tool for building, testing, and deploying Tezos software",
 	"main": "index.ts",
 	"directories": {

--- a/taqueria-analytics/package.json
+++ b/taqueria-analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/analytics",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A TypeScript SDK submitting events for Taqueria activity",
 	"main": "./index.js",
 	"source": "./index.ts",
@@ -35,7 +35,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/protocol": "^0.43.3",
+		"@taqueria/protocol": "^0.43.4",
 		"node-machine-id-xz": "^1.0.2"
 	},
 	"devDependencies": {

--- a/taqueria-analytics/package.json
+++ b/taqueria-analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/analytics",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A TypeScript SDK submitting events for Taqueria activity",
 	"main": "./index.js",
 	"source": "./index.ts",
@@ -35,7 +35,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/protocol": "^0.43.4",
+		"@taqueria/protocol": "^0.43.5",
 		"node-machine-id-xz": "^1.0.2"
 	},
 	"devDependencies": {

--- a/taqueria-lib-ligo/common.ts
+++ b/taqueria-lib-ligo/common.ts
@@ -90,10 +90,11 @@ export const emitExternalError = (
 	sendErr(`===`);
 };
 
-export const configure = (dockerImage: string, dockerImageEnvVar: string) => ({
+export const configure = (dockerImage: string, dockerImageEnvVar: string, canUseLIGOBinary: boolean) => ({
 	LIGO_DEFAULT_IMAGE: dockerImage,
 	LIGO_IMAGE_ENV_VAR: dockerImageEnvVar,
 	getLigoDockerImage: () => getDockerImage(dockerImage, dockerImageEnvVar),
+	baseDriverCmd: (projectDir: string) => baseDriverCmd(projectDir, dockerImage, canUseLIGOBinary),
 });
 
 export type Common = ReturnType<typeof configure>;
@@ -121,11 +122,12 @@ function getLigoBinaryFromPath() {
 	return null;
 }
 
-export function baseDriverCmd(
+function baseDriverCmd(
 	projectDir: string,
 	ligoDockerImage: string,
+	canUseLIGOBinary: boolean,
 ): string {
-	const ligoBinaryFromPath = getLigoBinaryFromPath();
+	const ligoBinaryFromPath = canUseLIGOBinary ? getLigoBinaryFromPath() : null;
 	if (ligoBinaryFromPath !== null) {
 		return ligoBinaryFromPath;
 	} else {

--- a/taqueria-lib-ligo/compile.ts
+++ b/taqueria-lib-ligo/compile.ts
@@ -13,10 +13,8 @@ import { access, readFile, writeFile } from 'fs/promises';
 import { basename, extname, join } from 'path';
 import * as readline from 'readline';
 import {
-	baseDriverCmd,
 	Common,
 	CompileOpts as Opts,
-	configure,
 	emitExternalError,
 	formatLigoError,
 	getInputFilenameAbsPath,
@@ -185,12 +183,7 @@ export const inject = (commonObj: Common) => {
 	): Promise<string> => {
 		const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
 		if (!projectDir) throw new Error(`No project directory provided`);
-		const baseCmd = `${
-			baseDriverCmd(
-				projectDir,
-				getLigoDockerImage(),
-			)
-		} info list-declarations`;
+		const baseCmd = `${commonObj.baseDriverCmd(projectDir)} info list-declarations`;
 		const inputFile = getInputFilenameRelPath(parsedArgs, sourceFile);
 		const flags = '--display-format json';
 		const cmd = `${baseCmd} ${inputFile} ${flags}`;
@@ -283,12 +276,7 @@ export const inject = (commonObj: Common) => {
 	): Promise<string> => {
 		const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
 		if (!projectDir) throw new Error(`No project directory provided`);
-		const baseCmd = `${
-			baseDriverCmd(
-				projectDir,
-				getLigoDockerImage(),
-			)
-		} compile contract`;
+		const baseCmd = `${commonObj.baseDriverCmd(projectDir)} compile contract`;
 		const inputFile = getInputFilenameRelPath(parsedArgs, sourceFile);
 		const outputFile = `-o ${getOutputContractFilename(parsedArgs, module)}`;
 		const flags = isOutputFormatJSON(parsedArgs)
@@ -335,12 +323,7 @@ export const inject = (commonObj: Common) => {
 		const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
 		if (!projectDir) throw new Error(`No project directory provided`);
 		const compilerType = isStorageKind(exprKind) ? 'storage' : 'parameter';
-		const baseCmd = `${
-			baseDriverCmd(
-				projectDir,
-				getLigoDockerImage(),
-			)
-		} compile ${compilerType}`;
+		const baseCmd = `${commonObj.baseDriverCmd(projectDir)} compile ${compilerType}`;
 		const inputFile = getInputFilenameRelPath(parsedArgs, sourceFile);
 		const outputFile = `-o ${
 			getOutputExprFilename(

--- a/taqueria-lib-ligo/compile.ts
+++ b/taqueria-lib-ligo/compile.ts
@@ -13,6 +13,7 @@ import { access, readFile, writeFile } from 'fs/promises';
 import { basename, extname, join } from 'path';
 import * as readline from 'readline';
 import {
+	baseDriverCmd,
 	Common,
 	CompileOpts as Opts,
 	configure,
@@ -52,7 +53,9 @@ export const isStorageListFile = (sourceFile: string): boolean =>
 	/.+\.(storageList|storages)\.(ligo|religo|mligo|jsligo)$/.test(sourceFile);
 
 export const isParameterListFile = (sourceFile: string): boolean =>
-	/.+\.(parameterList|parameters)\.(ligo|religo|mligo|jsligo)$/.test(sourceFile);
+	/.+\.(parameterList|parameters)\.(ligo|religo|mligo|jsligo)$/.test(
+		sourceFile,
+	);
 
 const extractExt = (path: string): string => {
 	const matchResult = path.match(/\.(ligo|religo|mligo|jsligo)$/);
@@ -66,12 +69,20 @@ const removeExt = (path: string): string => {
 
 const isOutputFormatJSON = (parsedArgs: Opts): boolean => parsedArgs.json;
 
-const getOutputContractFilename = (parsedArgs: Opts, module: ModuleInfo): string => {
+const getOutputContractFilename = (
+	parsedArgs: Opts,
+	module: ModuleInfo,
+): string => {
 	const ext = isOutputFormatJSON(parsedArgs) ? '.json' : '.tz';
 	return join(getArtifactsDir(parsedArgs), `${module.moduleName}${ext}`);
 };
 
-const getOutputExprFilename = (parsedArgs: Opts, module: ModuleInfo, exprKind: ExprKind, exprName: string): string => {
+const getOutputExprFilename = (
+	parsedArgs: Opts,
+	module: ModuleInfo,
+	exprKind: ExprKind,
+	exprName: string,
+): string => {
 	const contractName = module.moduleName;
 	const ext = isOutputFormatJSON(parsedArgs) ? '.json' : '.tz';
 	const outputFile = exprKind === 'default_storage'
@@ -80,7 +91,10 @@ const getOutputExprFilename = (parsedArgs: Opts, module: ModuleInfo, exprKind: E
 	return join(getArtifactsDir(parsedArgs), `${outputFile}`);
 };
 
-const getExprNames = (parsedArgs: Opts, sourceFile: string): Promise<string[]> => {
+const getExprNames = (
+	parsedArgs: Opts,
+	sourceFile: string,
+): Promise<string[]> => {
 	return new Promise((resolve, reject) => {
 		const inputFilePath = getInputFilenameAbsPath(parsedArgs, sourceFile);
 		const readInterface = readline.createInterface({
@@ -165,18 +179,28 @@ const initContentForParameter = (moduleInfo: ModuleInfo) => getContent(moduleInf
 export const inject = (commonObj: Common) => {
 	const { getLigoDockerImage } = commonObj;
 
-	const getListDeclarationsCmd = async (parsedArgs: UnionOpts, sourceFile: string): Promise<string> => {
+	const getListDeclarationsCmd = async (
+		parsedArgs: UnionOpts,
+		sourceFile: string,
+	): Promise<string> => {
 		const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
 		if (!projectDir) throw new Error(`No project directory provided`);
-		const baseCmd =
-			`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project -u $(id -u):$(id -g) ${getLigoDockerImage()} info list-declarations`;
+		const baseCmd = `${
+			baseDriverCmd(
+				projectDir,
+				getLigoDockerImage(),
+			)
+		} info list-declarations`;
 		const inputFile = getInputFilenameRelPath(parsedArgs, sourceFile);
 		const flags = '--display-format json';
 		const cmd = `${baseCmd} ${inputFile} ${flags}`;
 		return cmd;
 	};
 
-	const listContractModules = async (parsedArgs: UnionOpts, sourceFile: string): Promise<ModuleInfo[]> => {
+	const listContractModules = async (
+		parsedArgs: UnionOpts,
+		sourceFile: string,
+	): Promise<ModuleInfo[]> => {
 		try {
 			await getArch();
 			const cmd = await getListDeclarationsCmd(parsedArgs, sourceFile);
@@ -195,27 +219,51 @@ export const inject = (commonObj: Common) => {
 					const syntax = extractExt(sourceFile).replace('.', '');
 
 					if (decl === 'main') {
-						return [...acc, { moduleName: srcFile, sourceName: sourceFile, sourceFile, type: 'file-main', syntax }];
+						return [
+							...acc,
+							{
+								moduleName: srcFile,
+								sourceName: sourceFile,
+								sourceFile,
+								type: 'file-main',
+								syntax,
+							},
+						];
 					} else if (decl === '$main') {
-						return [...acc, { moduleName: srcFile, sourceName: sourceFile, sourceFile, type: 'file-entry', syntax }];
+						return [
+							...acc,
+							{
+								moduleName: srcFile,
+								sourceName: sourceFile,
+								sourceFile,
+								type: 'file-entry',
+								syntax,
+							},
+						];
 					} else if (decl.endsWith('.main')) {
 						const moduleName = decl.replace(/\.main$/, '');
-						return [...acc, {
-							moduleName,
-							sourceName: `${sourceFile}/${moduleName}`,
-							sourceFile,
-							type: 'module-main',
-							syntax,
-						}];
+						return [
+							...acc,
+							{
+								moduleName,
+								sourceName: `${sourceFile}/${moduleName}`,
+								sourceFile,
+								type: 'module-main',
+								syntax,
+							},
+						];
 					} else if (decl.endsWith('.$main')) {
 						const moduleName = decl.replace(/\.\$main$/, '');
-						return [...acc, {
-							moduleName,
-							sourceName: `${sourceFile}/${moduleName}`,
-							sourceFile,
-							type: 'module-entry',
-							syntax,
-						}];
+						return [
+							...acc,
+							{
+								moduleName,
+								sourceName: `${sourceFile}/${moduleName}`,
+								sourceFile,
+								type: 'module-entry',
+								syntax,
+							},
+						];
 					}
 					return acc;
 				},
@@ -228,20 +276,36 @@ export const inject = (commonObj: Common) => {
 		}
 	};
 
-	const getCompileContractCmd = async (parsedArgs: Opts, sourceFile: string, module: ModuleInfo): Promise<string> => {
+	const getCompileContractCmd = async (
+		parsedArgs: Opts,
+		sourceFile: string,
+		module: ModuleInfo,
+	): Promise<string> => {
 		const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
 		if (!projectDir) throw new Error(`No project directory provided`);
-		const baseCmd =
-			`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project -u $(id -u):$(id -g) ${getLigoDockerImage()} compile contract`;
+		const baseCmd = `${
+			baseDriverCmd(
+				projectDir,
+				getLigoDockerImage(),
+			)
+		} compile contract`;
 		const inputFile = getInputFilenameRelPath(parsedArgs, sourceFile);
 		const outputFile = `-o ${getOutputContractFilename(parsedArgs, module)}`;
-		const flags = isOutputFormatJSON(parsedArgs) ? ' --michelson-format json ' : '';
-		const moduleFlag = module.type.startsWith('file-') ? '' : `-m ${module.moduleName}`;
+		const flags = isOutputFormatJSON(parsedArgs)
+			? ' --michelson-format json '
+			: '';
+		const moduleFlag = module.type.startsWith('file-')
+			? ''
+			: `-m ${module.moduleName}`;
 		const cmd = `${baseCmd} ${inputFile} ${outputFile} ${flags}${moduleFlag}`;
 		return cmd;
 	};
 
-	const compileContract = async (parsedArgs: Opts, sourceFile: string, module: ModuleInfo): Promise<TableRow> => {
+	const compileContract = async (
+		parsedArgs: Opts,
+		sourceFile: string,
+		module: ModuleInfo,
+	): Promise<TableRow> => {
 		try {
 			await getArch();
 			const cmd = await getCompileContractCmd(parsedArgs, sourceFile, module);
@@ -271,11 +335,24 @@ export const inject = (commonObj: Common) => {
 		const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
 		if (!projectDir) throw new Error(`No project directory provided`);
 		const compilerType = isStorageKind(exprKind) ? 'storage' : 'parameter';
-		const baseCmd =
-			`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project -u $(id -u):$(id -g) ${getLigoDockerImage()} compile ${compilerType}`;
+		const baseCmd = `${
+			baseDriverCmd(
+				projectDir,
+				getLigoDockerImage(),
+			)
+		} compile ${compilerType}`;
 		const inputFile = getInputFilenameRelPath(parsedArgs, sourceFile);
-		const outputFile = `-o ${getOutputExprFilename(parsedArgs, module, exprKind, exprName)}`;
-		const flags = isOutputFormatJSON(parsedArgs) ? ' --michelson-format json ' : '';
+		const outputFile = `-o ${
+			getOutputExprFilename(
+				parsedArgs,
+				module,
+				exprKind,
+				exprName,
+			)
+		}`;
+		const flags = isOutputFormatJSON(parsedArgs)
+			? ' --michelson-format json '
+			: '';
 
 		// Parameter and Storage list files are expected to import the smart contract file as the "Contract" module.
 		const moduleFlag = (() => {
@@ -292,28 +369,37 @@ export const inject = (commonObj: Common) => {
 		return cmd;
 	};
 
-	const compileExpr =
-		(parsedArgs: Opts, sourceFile: string, module: ModuleInfo, exprKind: ExprKind) =>
-		(exprName: string): Promise<TableRow> => {
-			return getArch()
-				.then(() => getCompileExprCmd(parsedArgs, sourceFile, module, exprKind, exprName))
-				.then(execCmd)
-				.then(({ stderr }) => {
-					if (stderr.length > 0) sendWarn(stderr);
-					const artifactName = getOutputExprFilename(parsedArgs, module, exprKind, exprName);
-					return {
-						source: module.sourceName,
-						artifact: artifactName,
-					};
-				})
-				.catch(err => {
-					return {
-						source: module.sourceName,
-						artifact: `${exprName} in ${sourceFile} not compiled`,
-						err,
-					};
-				});
-		};
+	const compileExpr = (
+		parsedArgs: Opts,
+		sourceFile: string,
+		module: ModuleInfo,
+		exprKind: ExprKind,
+	) =>
+	(exprName: string): Promise<TableRow> => {
+		return getArch()
+			.then(() => getCompileExprCmd(parsedArgs, sourceFile, module, exprKind, exprName))
+			.then(execCmd)
+			.then(({ stderr }) => {
+				if (stderr.length > 0) sendWarn(stderr);
+				const artifactName = getOutputExprFilename(
+					parsedArgs,
+					module,
+					exprKind,
+					exprName,
+				);
+				return {
+					source: module.sourceName,
+					artifact: artifactName,
+				};
+			})
+			.catch(err => {
+				return {
+					source: module.sourceName,
+					artifact: `${exprName} in ${sourceFile} not compiled`,
+					err,
+				};
+			});
+	};
 
 	const compileExprs = async (
 		parsedArgs: Opts,
@@ -327,45 +413,51 @@ export const inject = (commonObj: Common) => {
 			exprs = await getExprNames(parsedArgs, sourceFile);
 		} catch (err) {
 			emitExternalError(err, sourceFile);
-			return [{
-				source: module.sourceName,
-				artifact: `No ${isStorageKind(exprKind) ? 'storage' : 'parameter'} expressions compiled`,
-			}];
+			return [
+				{
+					source: module.sourceName,
+					artifact: `No ${isStorageKind(exprKind) ? 'storage' : 'parameter'} expressions compiled`,
+				},
+			];
 		}
 
-		const results = await Promise.all(exprs.map(async (exprName, index) => {
-			const compileResult = await compileExpr(
-				parsedArgs,
-				sourceFile,
-				module,
-				exprKind === 'storage' && index === 0 ? 'default_storage' : exprKind,
-			)(exprName);
-			return compileResult;
-		}));
-
-		// Collect errors
-		const errors = results.reduce(
-			(acc, result) => {
-				if (result.err) {
-					// If its not an Error object, then just add it to the list
-					if (!(result.err instanceof Error)) return [...acc, result.err];
-
-					// Otherwise, get all ligo errors and ensure that the list is unique
-					const ligoErrs = (acc
-						.filter(err => err instanceof Error) as Error[])
-						.map(err => err.message);
-
-					const formattedError = formatLigoError(result.err);
-
-					return (ligoErrs.includes(formattedError.message)) ? acc : [...acc, formattedError];
-				}
-				return acc;
-			},
-			[] as unknown[],
+		const results = await Promise.all(
+			exprs.map(async (exprName, index) => {
+				const compileResult = await compileExpr(
+					parsedArgs,
+					sourceFile,
+					module,
+					exprKind === 'storage' && index === 0 ? 'default_storage' : exprKind,
+				)(exprName);
+				return compileResult;
+			}),
 		);
 
+		// Collect errors
+		const errors = results.reduce((acc, result) => {
+			if (result.err) {
+				// If its not an Error object, then just add it to the list
+				if (!(result.err instanceof Error)) return [...acc, result.err];
+
+				// Otherwise, get all ligo errors and ensure that the list is unique
+				const ligoErrs = (
+					acc.filter(err => err instanceof Error) as Error[]
+				).map(err => err.message);
+
+				const formattedError = formatLigoError(result.err);
+
+				return ligoErrs.includes(formattedError.message)
+					? acc
+					: [...acc, formattedError];
+			}
+			return acc;
+		}, [] as unknown[]);
+
 		// Collect table rows
-		const retval = results.map(({ source, artifact }) => ({ source, artifact }));
+		const retval = results.map(({ source, artifact }) => ({
+			source,
+			artifact,
+		}));
 
 		if (errors.length) emitExternalError(errors, sourceFile);
 
@@ -377,39 +469,71 @@ export const inject = (commonObj: Common) => {
 		sourceFile: string,
 		module: ModuleInfo,
 	): Promise<TableRow[]> => {
-		const contractCompileResult = await compileContract(parsedArgs, sourceFile, module);
+		const contractCompileResult = await compileContract(
+			parsedArgs,
+			sourceFile,
+			module,
+		);
 		if (contractCompileResult.artifact === COMPILE_ERR_MSG) return [contractCompileResult];
 
-		const storageListFile = `${module.moduleName}.storageList${extractExt(sourceFile)}`;
-		const storageListFilename = getInputFilenameAbsPath(parsedArgs, storageListFile);
+		const storageListFile = `${module.moduleName}.storageList${
+			extractExt(
+				sourceFile,
+			)
+		}`;
+		const storageListFilename = getInputFilenameAbsPath(
+			parsedArgs,
+			storageListFile,
+		);
 		const storageCompileResult = await access(storageListFilename)
 			.then(() => compileExprs(parsedArgs, storageListFile, module, 'storage'))
 			.catch(() => {
 				sendWarn(
 					`Note: storage file associated with "${module.moduleName}" can't be found, so "${storageListFile}" has been created for you. Use this file to define all initial storage values for this contract\n`,
 				);
-				return writeFile(storageListFilename, initContentForStorage(module), 'utf8');
+				return writeFile(
+					storageListFilename,
+					initContentForStorage(module),
+					'utf8',
+				);
 			});
 
-		const parameterListFile = `${module.moduleName}.parameterList${extractExt(sourceFile)}`;
-		const parameterListFilename = getInputFilenameAbsPath(parsedArgs, parameterListFile);
+		const parameterListFile = `${module.moduleName}.parameterList${
+			extractExt(
+				sourceFile,
+			)
+		}`;
+		const parameterListFilename = getInputFilenameAbsPath(
+			parsedArgs,
+			parameterListFile,
+		);
 		const parameterCompileResult = await access(parameterListFilename)
 			.then(() => compileExprs(parsedArgs, parameterListFile, module, 'parameter'))
 			.catch(() => {
 				sendWarn(
 					`Note: parameter file associated with "${module.moduleName}" can't be found, so "${parameterListFile}" has been created for you. Use this file to define all parameter values for this contract\n`,
 				);
-				return writeFile(parameterListFilename, initContentForParameter(module), 'utf8');
+				return writeFile(
+					parameterListFilename,
+					initContentForParameter(module),
+					'utf8',
+				);
 			});
 
-		const storageArtifacts = storageCompileResult ? storageCompileResult.map(res => res.artifact).join('\n') : '';
-		const parameterArtifacts = parameterCompileResult ? parameterCompileResult.map(res => res.artifact).join('\n') : '';
+		const storageArtifacts = storageCompileResult
+			? storageCompileResult.map(res => res.artifact).join('\n')
+			: '';
+		const parameterArtifacts = parameterCompileResult
+			? parameterCompileResult.map(res => res.artifact).join('\n')
+			: '';
 
 		const combinedArtifact = [
 			contractCompileResult.artifact,
 			storageArtifacts,
 			parameterArtifacts,
-		].filter(Boolean).join('\n');
+		]
+			.filter(Boolean)
+			.join('\n');
 
 		const combinedRow: TableRow = {
 			source: module.sourceName,
@@ -432,7 +556,10 @@ export const inject = (commonObj: Common) => {
 	};
 };
 
-export const compile = async (commonObj: Common, parsedArgs: Opts): Promise<void> => {
+export const compile = async (
+	commonObj: Common,
+	parsedArgs: Opts,
+): Promise<void> => {
 	const { listContractModules, compileContractWithStorageAndParameter } = inject(commonObj);
 
 	const sourceFile = parsedArgs.sourceFile;
@@ -441,11 +568,15 @@ export const compile = async (commonObj: Common, parsedArgs: Opts): Promise<void
 		return;
 	}
 	if (isStorageListFile(sourceFile) || isParameterListFile(sourceFile)) {
-		sendErr(`Storage and parameter list files are not meant to be compiled directly`);
+		sendErr(
+			`Storage and parameter list files are not meant to be compiled directly`,
+		);
 		return;
 	}
 	if (isUnsupportedLigoSyntax(sourceFile)) {
-		sendErr(`Unsupported LIGO syntax detected in ${sourceFile}. Note, we only support .jsligo and .mligo files.`);
+		sendErr(
+			`Unsupported LIGO syntax detected in ${sourceFile}. Note, we only support .jsligo and .mligo files.`,
+		);
 		return;
 	}
 
@@ -466,11 +597,17 @@ export const compile = async (commonObj: Common, parsedArgs: Opts): Promise<void
 			// If we're only to compile a particular module, then we'll skip any that don't match
 			if (parsedArgs.module && parsedArgs.module !== module.moduleName) continue;
 
-			const compileResults = await compileContractWithStorageAndParameter(parsedArgs, sourceFile, module);
+			const compileResults = await compileContractWithStorageAndParameter(
+				parsedArgs,
+				sourceFile,
+				module,
+			);
 			allCompileResults = allCompileResults.concat(compileResults);
 		}
 
-		sendJsonRes(allCompileResults, { footer: `\nCompiled ${allCompileResults.length} contract(s) in "${sourceFile}"` });
+		sendJsonRes(allCompileResults, {
+			footer: `\nCompiled ${allCompileResults.length} contract(s) in "${sourceFile}"`,
+		});
 	} catch (err) {
 		sendErr(`Error processing "${sourceFile}": ${err}`);
 	}

--- a/taqueria-lib-ligo/index.ts
+++ b/taqueria-lib-ligo/index.ts
@@ -12,6 +12,7 @@ type ConfiguratorArgs = {
 	unparsedArgs: string[];
 	dockerImage: string;
 	dockerImageEnvVar: string;
+	canUseLIGOBinary: boolean;
 	templates?: Record<string, string>;
 };
 
@@ -114,7 +115,7 @@ export const configurePlugin = (settings: ConfiguratorArgs) => {
 				handler: createContract(settings.templates),
 			}),
 		],
-		proxy: main(settings.dockerImage, settings.dockerImageEnvVar),
+		proxy: main(settings.dockerImage, settings.dockerImageEnvVar, settings.canUseLIGOBinary),
 		postInstall: `node ${__dirname}/postinstall.js`,
 	};
 

--- a/taqueria-lib-ligo/ligo.ts
+++ b/taqueria-lib-ligo/ligo.ts
@@ -1,7 +1,5 @@
-import { execCmd, getArch, sendAsyncErr, sendRes, spawnCmd } from '@taqueria/node-sdk';
-import { readJsonFile, writeJsonFile } from '@taqueria/node-sdk';
-import { join } from 'path';
-import { baseDriverCmd, Common, configure, LigoOpts as Opts } from './common';
+import { sendAsyncErr, sendRes, spawnCmd } from '@taqueria/node-sdk';
+import { Common, LigoOpts as Opts } from './common';
 
 const getArbitraryLigoCmd = (
 	commonObj: Common,
@@ -9,7 +7,6 @@ const getArbitraryLigoCmd = (
 	userArgs: string,
 ): [string, Record<string, string>] => {
 	const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
-	const { getLigoDockerImage } = commonObj;
 	if (!projectDir) throw `No project directory provided`;
 
 	const processedUserArgs = userArgs
@@ -17,12 +14,7 @@ const getArbitraryLigoCmd = (
 		.map(arg => (arg.startsWith('\\-') ? arg.substring(1) : arg))
 		.filter(arg => arg);
 
-	const cmd = `${
-		baseDriverCmd(
-			projectDir,
-			getLigoDockerImage(),
-		)
-	} ${processedUserArgs.join(' ')}`;
+	const cmd = `${commonObj.baseDriverCmd(projectDir)} ${processedUserArgs.join(' ')}`;
 
 	const envVars = { DOCKER_DEFAULT_PLATFORM: 'linux/amd64' };
 	return [cmd, envVars];

--- a/taqueria-lib-ligo/ligo.ts
+++ b/taqueria-lib-ligo/ligo.ts
@@ -1,61 +1,53 @@
 import { execCmd, getArch, sendAsyncErr, sendRes, spawnCmd } from '@taqueria/node-sdk';
 import { readJsonFile, writeJsonFile } from '@taqueria/node-sdk';
 import { join } from 'path';
-import { Common, configure, LigoOpts as Opts } from './common';
+import { baseDriverCmd, Common, configure, LigoOpts as Opts } from './common';
 
 const getArbitraryLigoCmd = (
 	commonObj: Common,
 	parsedArgs: Opts,
-	uid: string,
-	gid: string,
 	userArgs: string,
 ): [string, Record<string, string>] => {
 	const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
+	const { getLigoDockerImage } = commonObj;
 	if (!projectDir) throw `No project directory provided`;
 
-	const userMap = uid && gid ? `${uid}:${gid}` : uid;
-	const userMapArgs = uid ? ['-u', userMap] : [];
+	const processedUserArgs = userArgs
+		.split(' ')
+		.map(arg => (arg.startsWith('\\-') ? arg.substring(1) : arg))
+		.filter(arg => arg);
 
-	const binary = 'docker';
-	const baseArgs = [
-		'run',
-		'--rm',
-		'-v',
-		`${projectDir}:/project`,
-		'-w',
-		'/project',
-		...userMapArgs,
-		commonObj.getLigoDockerImage(),
-	];
-	const processedUserArgs = userArgs.split(' ').map(arg => arg.startsWith('\\-') ? arg.substring(1) : arg).filter(arg =>
-		arg
-	);
-	const args = [...baseArgs, ...processedUserArgs, '--skip-analytics'];
-	const envVars = { 'DOCKER_DEFAULT_PLATFORM': 'linux/amd64' };
-	return [
-		[binary, ...args].join(' '),
-		envVars,
-	];
+	const cmd = `${
+		baseDriverCmd(
+			projectDir,
+			getLigoDockerImage(),
+		)
+	} ${processedUserArgs.join(' ')}`;
+
+	const envVars = { DOCKER_DEFAULT_PLATFORM: 'linux/amd64' };
+	return [cmd, envVars];
 };
 
-const runArbitraryLigoCmd = (commonObj: Common, parsedArgs: Opts, cmd: string): Promise<string> =>
-	(async () => {
-		const uid = await execCmd('id -u');
-		const gid = await execCmd('id -g');
-		return [uid.stdout.trim(), gid.stdout.trim()];
-	})()
-		.then(([uid, gid]) => getArbitraryLigoCmd(commonObj, parsedArgs, uid, gid, cmd))
-		.then(([cmd, envVars]) => spawnCmd(cmd, envVars))
+const runArbitraryLigoCmd = (
+	commonObj: Common,
+	parsedArgs: Opts,
+	userCmd: string,
+): Promise<string> => {
+	let [cmd, envVars] = getArbitraryLigoCmd(commonObj, parsedArgs, userCmd);
+	return spawnCmd(cmd, envVars)
 		.then(code =>
 			code !== null && code === 0
 				? `Command "${cmd}" ran successfully by LIGO`
 				: `Command "${cmd}" failed. Please check your command`
 		)
 		.catch(err => sendAsyncErr(`An internal error has occurred: ${err.message}`));
+};
 
 const ligo = (commonObj: Common, parsedArgs: Opts): Promise<void> => {
 	const args = parsedArgs.command;
-	return runArbitraryLigoCmd(commonObj, parsedArgs, args).then(sendRes).catch(err => sendAsyncErr(err, false));
+	return runArbitraryLigoCmd(commonObj, parsedArgs, args)
+		.then(sendRes)
+		.catch(err => sendAsyncErr(err, false));
 };
 
 export default ligo;

--- a/taqueria-lib-ligo/main.ts
+++ b/taqueria-lib-ligo/main.ts
@@ -5,23 +5,25 @@ import compileAll from './compile-all';
 import ligo from './ligo';
 import test from './test';
 
-const main = (dockerImage: string, dockerImageEnvVar: string) => (parsedArgs: RequestArgs.t): Promise<void> => {
-	const commonObj = configure(dockerImage, dockerImageEnvVar);
-	const unsafeOpts = parsedArgs as unknown as Opts;
-	switch (unsafeOpts.task) {
-		case 'ligo':
-			return ligo(commonObj, unsafeOpts);
-		case 'compile':
-			return compile(commonObj, unsafeOpts);
-		case 'compile-all':
-			return compileAll(commonObj, unsafeOpts);
-		case 'test':
-			return test(commonObj, parsedArgs);
-		case 'get-image':
-			return sendAsyncRes(commonObj.getLigoDockerImage());
-		default:
-			return sendAsyncErr(`${unsafeOpts.task} is not an understood task by the LIGO plugin`);
-	}
-};
+const main =
+	(dockerImage: string, dockerImageEnvVar: string, canUseLIGOBinary: boolean) =>
+	(parsedArgs: RequestArgs.t): Promise<void> => {
+		const commonObj = configure(dockerImage, dockerImageEnvVar, canUseLIGOBinary);
+		const unsafeOpts = parsedArgs as unknown as Opts;
+		switch (unsafeOpts.task) {
+			case 'ligo':
+				return ligo(commonObj, unsafeOpts);
+			case 'compile':
+				return compile(commonObj, unsafeOpts);
+			case 'compile-all':
+				return compileAll(commonObj, unsafeOpts);
+			case 'test':
+				return test(commonObj, parsedArgs);
+			case 'get-image':
+				return sendAsyncRes(commonObj.getLigoDockerImage());
+			default:
+				return sendAsyncErr(`${unsafeOpts.task} is not an understood task by the LIGO plugin`);
+		}
+	};
 
 export default main;

--- a/taqueria-lib-ligo/package.json
+++ b/taqueria-lib-ligo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/lib-ligo",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A taqueria library which provides common functionality for the LIGO and LIGO Legacy Plugins",
 	"targets": {
 		"default": {
@@ -41,7 +41,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-lib-ligo/package.json
+++ b/taqueria-lib-ligo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/lib-ligo",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A taqueria library which provides common functionality for the LIGO and LIGO Legacy Plugins",
 	"targets": {
 		"default": {
@@ -41,7 +41,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-lib-ligo/test.ts
+++ b/taqueria-lib-ligo/test.ts
@@ -1,20 +1,15 @@
 import { execCmd, getArch, sendAsyncErr, sendJsonRes, sendWarn } from '@taqueria/node-sdk';
-import { baseDriverCmd, Common, emitExternalError, getInputFilenameRelPath, TestOpts as Opts } from './common';
+import { Common, emitExternalError, getInputFilenameRelPath, TestOpts as Opts } from './common';
 
 type TableRow = { contract: string; testResults: string };
 
 const inject = (commonObj: Common) => {
-	const { getLigoDockerImage } = commonObj;
+	const { baseDriverCmd } = commonObj;
 
 	const getTestContractCmd = (parsedArgs: Opts, sourceFile: string): string => {
 		const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
 		if (!projectDir) throw `No project directory provided`;
-		const baseCmd = `${
-			baseDriverCmd(
-				projectDir,
-				getLigoDockerImage(),
-			)
-		} run test`;
+		const baseCmd = `${baseDriverCmd(projectDir)} run test`;
 		const inputFile = getInputFilenameRelPath(parsedArgs, sourceFile);
 		const cmd = `${baseCmd} ${inputFile}`;
 		return cmd;

--- a/taqueria-lib-ligo/test.ts
+++ b/taqueria-lib-ligo/test.ts
@@ -1,5 +1,5 @@
 import { execCmd, getArch, sendAsyncErr, sendJsonRes, sendWarn } from '@taqueria/node-sdk';
-import { Common, emitExternalError, getInputFilenameRelPath, TestOpts as Opts } from './common';
+import { baseDriverCmd, Common, emitExternalError, getInputFilenameRelPath, TestOpts as Opts } from './common';
 
 type TableRow = { contract: string; testResults: string };
 
@@ -9,14 +9,21 @@ const inject = (commonObj: Common) => {
 	const getTestContractCmd = (parsedArgs: Opts, sourceFile: string): string => {
 		const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
 		if (!projectDir) throw `No project directory provided`;
-		const baseCmd =
-			`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project -u $(id -u):$(id -g) ${getLigoDockerImage()} run test`;
+		const baseCmd = `${
+			baseDriverCmd(
+				projectDir,
+				getLigoDockerImage(),
+			)
+		} run test`;
 		const inputFile = getInputFilenameRelPath(parsedArgs, sourceFile);
 		const cmd = `${baseCmd} ${inputFile}`;
 		return cmd;
 	};
 
-	const testContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow> =>
+	const testContract = (
+		parsedArgs: Opts,
+		sourceFile: string,
+	): Promise<TableRow> =>
 		getArch()
 			.then(() => getTestContractCmd(parsedArgs, sourceFile))
 			.then(execCmd)
@@ -47,9 +54,10 @@ const test = (commonObj: Common, parsedArgs: Opts): Promise<void> => {
 
 	const sourceFile = parsedArgs.sourceFile;
 	if (!sourceFile) return sendAsyncErr(`No source file provided`);
-	return testContract(parsedArgs, sourceFile).then(result => [result]).then(sendJsonRes).catch(err =>
-		sendAsyncErr(err, false)
-	);
+	return testContract(parsedArgs, sourceFile)
+		.then(result => [result])
+		.then(sendJsonRes)
+		.catch(err => sendAsyncErr(err, false));
 };
 
 export default test;

--- a/taqueria-plugin-archetype/package.json
+++ b/taqueria-plugin-archetype/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-archetype",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A taqueria plugin for compiling Archetype smart contracts",
 	"targets": {
 		"default": {
@@ -40,7 +40,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
 		"fast-glob": "^3.3.1",
 		"ts-pattern": "^5.0.5"
 	},

--- a/taqueria-plugin-archetype/package.json
+++ b/taqueria-plugin-archetype/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-archetype",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A taqueria plugin for compiling Archetype smart contracts",
 	"targets": {
 		"default": {
@@ -40,7 +40,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
 		"fast-glob": "^3.3.1",
 		"ts-pattern": "^5.0.5"
 	},

--- a/taqueria-plugin-contract-types/package.json
+++ b/taqueria-plugin-contract-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-contract-types",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"main": "index.cjs",
 	"module": "index.js",
 	"source": "index.ts",
@@ -34,7 +34,7 @@
 		"typescript": "^5.2.2"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
 		"@taquito/michel-codec": "^18.0.0-RC.0",
 		"@taquito/signer": "^18.0.0-RC.0",
 		"@taquito/taquito": "^18.0.0-RC.0",

--- a/taqueria-plugin-contract-types/package.json
+++ b/taqueria-plugin-contract-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-contract-types",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"main": "index.cjs",
 	"module": "index.js",
 	"source": "index.ts",
@@ -34,7 +34,7 @@
 		"typescript": "^5.2.2"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
 		"@taquito/michel-codec": "^18.0.0-RC.0",
 		"@taquito/signer": "^18.0.0-RC.0",
 		"@taquito/taquito": "^18.0.0-RC.0",

--- a/taqueria-plugin-core/package.json
+++ b/taqueria-plugin-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-core",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A taqueria plugin for core tasks",
 	"targets": {
 		"default": {
@@ -43,7 +43,7 @@
 		"typescript": "^5.2.2"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3"
+		"@taqueria/node-sdk": "^0.43.4"
 	},
 	"tsup": {
 		"entry": [

--- a/taqueria-plugin-core/package.json
+++ b/taqueria-plugin-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-core",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A taqueria plugin for core tasks",
 	"targets": {
 		"default": {
@@ -43,7 +43,7 @@
 		"typescript": "^5.2.2"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4"
+		"@taqueria/node-sdk": "^0.43.5"
 	},
 	"tsup": {
 		"entry": [

--- a/taqueria-plugin-flextesa/package.json
+++ b/taqueria-plugin-flextesa/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-flextesa",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A plugin for Taqueria providing local sandbox capabilities built on Flextesa",
 	"keywords": [
 		"taqueria",
@@ -34,8 +34,8 @@
 		"directory": "taqueria-plugin-flextesa"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3",
-		"@taqueria/protocol": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/protocol": "^0.43.4",
 		"async-retry": "^1.3.3",
 		"bignumber.js": "^9.1.2",
 		"fast-glob": "^3.2.12",

--- a/taqueria-plugin-flextesa/package.json
+++ b/taqueria-plugin-flextesa/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-flextesa",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A plugin for Taqueria providing local sandbox capabilities built on Flextesa",
 	"keywords": [
 		"taqueria",
@@ -34,8 +34,8 @@
 		"directory": "taqueria-plugin-flextesa"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4",
-		"@taqueria/protocol": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
+		"@taqueria/protocol": "^0.43.5",
 		"async-retry": "^1.3.3",
 		"bignumber.js": "^9.1.2",
 		"fast-glob": "^3.2.12",

--- a/taqueria-plugin-helloworld/package.json
+++ b/taqueria-plugin-helloworld/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-helloworld",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "An example of a plugin for Taqueria",
 	"main": "index.js",
 	"scripts": {

--- a/taqueria-plugin-helloworld/package.json
+++ b/taqueria-plugin-helloworld/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-helloworld",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "An example of a plugin for Taqueria",
 	"main": "index.js",
 	"scripts": {

--- a/taqueria-plugin-ipfs-pinata/package.json
+++ b/taqueria-plugin-ipfs-pinata/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-ipfs-pinata",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A plugin for Taqueria providing ipfs publishing and pinning using the Pinata service",
 	"keywords": [
 		"taqueria",
@@ -34,7 +34,7 @@
 	},
 	"dependencies": {
 		"@helia/unixfs": "^1.4.2",
-		"@taqueria/node-sdk": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
 		"dotenv": "^16.3.1",
 		"form-data": "^4.0.0",
 		"helia": "^2.0.3",

--- a/taqueria-plugin-ipfs-pinata/package.json
+++ b/taqueria-plugin-ipfs-pinata/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-ipfs-pinata",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A plugin for Taqueria providing ipfs publishing and pinning using the Pinata service",
 	"keywords": [
 		"taqueria",
@@ -34,7 +34,7 @@
 	},
 	"dependencies": {
 		"@helia/unixfs": "^1.4.2",
-		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
 		"dotenv": "^16.3.1",
 		"form-data": "^4.0.0",
 		"helia": "^2.0.3",

--- a/taqueria-plugin-jest/package.json
+++ b/taqueria-plugin-jest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-jest",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"main": "index.cjs",
 	"module": "index.js",
 	"source": "index.ts",
@@ -27,8 +27,8 @@
 		"directory": "taqueria-plugin-jest"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4",
-		"@taqueria/plugin-contract-types": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
+		"@taqueria/plugin-contract-types": "^0.43.5",
 		"@taquito/signer": "^18.0.0-RC.0",
 		"@taquito/taquito": "^18.0.0-RC.0",
 		"@taquito/utils": "^18.0.0-RC.0",

--- a/taqueria-plugin-jest/package.json
+++ b/taqueria-plugin-jest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-jest",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"main": "index.cjs",
 	"module": "index.js",
 	"source": "index.ts",
@@ -27,8 +27,8 @@
 		"directory": "taqueria-plugin-jest"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3",
-		"@taqueria/plugin-contract-types": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/plugin-contract-types": "^0.43.4",
 		"@taquito/signer": "^18.0.0-RC.0",
 		"@taquito/taquito": "^18.0.0-RC.0",
 		"@taquito/utils": "^18.0.0-RC.0",

--- a/taqueria-plugin-ligo-legacy/index.ts
+++ b/taqueria-plugin-ligo-legacy/index.ts
@@ -6,4 +6,5 @@ configurePlugin({
 	dockerImage: 'ligolang/ligo:0.73.0',
 	dockerImageEnvVar: 'TAQ_LIGO_LEGACY_IMAGE',
 	unparsedArgs: process.argv,
+	canUseLIGOBinary: false,
 });

--- a/taqueria-plugin-ligo-legacy/package.json
+++ b/taqueria-plugin-ligo-legacy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-ligo-legacy",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A taqueria plugin for compiling LIGO smart contracts that target LIGO v0.73.0 and earlier.",
 	"targets": {
 		"default": {
@@ -41,8 +41,8 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/lib-ligo": "^0.43.4",
-		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/lib-ligo": "^0.43.5",
+		"@taqueria/node-sdk": "^0.43.5",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-ligo-legacy/package.json
+++ b/taqueria-plugin-ligo-legacy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-ligo-legacy",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A taqueria plugin for compiling LIGO smart contracts that target LIGO v0.73.0 and earlier.",
 	"targets": {
 		"default": {
@@ -41,8 +41,8 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/lib-ligo": "^0.43.3",
-		"@taqueria/node-sdk": "^0.43.3",
+		"@taqueria/lib-ligo": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.4",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-ligo/index.ts
+++ b/taqueria-plugin-ligo/index.ts
@@ -6,6 +6,7 @@ configurePlugin({
 	alias: 'ligo',
 	dockerImage: 'ligolang/ligo:1.0.0',
 	dockerImageEnvVar: 'TAQ_LIGO_IMAGE',
+	canUseLIGOBinary: true,
 	unparsedArgs: process.argv,
 	templates,
 });

--- a/taqueria-plugin-ligo/package.json
+++ b/taqueria-plugin-ligo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-ligo",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A taqueria plugin for compiling LIGO smart contracts",
 	"targets": {
 		"default": {
@@ -41,8 +41,8 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/lib-ligo": "^0.43.4",
-		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/lib-ligo": "^0.43.5",
+		"@taqueria/node-sdk": "^0.43.5",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-ligo/package.json
+++ b/taqueria-plugin-ligo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-ligo",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A taqueria plugin for compiling LIGO smart contracts",
 	"targets": {
 		"default": {
@@ -41,8 +41,8 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/lib-ligo": "^0.43.3",
-		"@taqueria/node-sdk": "^0.43.3",
+		"@taqueria/lib-ligo": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.4",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-metadata/package.json
+++ b/taqueria-plugin-metadata/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-metadata",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A plugin for Taqueria providing metadata creation and validation.",
 	"keywords": [
 		"taqueria",
@@ -31,8 +31,8 @@
 		"directory": "taqueria-plugin-metadata"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4",
-		"@taqueria/protocol": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
+		"@taqueria/protocol": "^0.43.5",
 		"prompts": "^2.4.2"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-metadata/package.json
+++ b/taqueria-plugin-metadata/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-metadata",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A plugin for Taqueria providing metadata creation and validation.",
 	"keywords": [
 		"taqueria",
@@ -31,8 +31,8 @@
 		"directory": "taqueria-plugin-metadata"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3",
-		"@taqueria/protocol": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/protocol": "^0.43.4",
 		"prompts": "^2.4.2"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-mock/package.json
+++ b/taqueria-plugin-mock/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-mock",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A plugin used to test Taqueria",
 	"private": true,
 	"scripts": {
@@ -23,6 +23,6 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3"
+		"@taqueria/node-sdk": "^0.43.4"
 	}
 }

--- a/taqueria-plugin-mock/package.json
+++ b/taqueria-plugin-mock/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-mock",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A plugin used to test Taqueria",
 	"private": true,
 	"scripts": {
@@ -23,6 +23,6 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4"
+		"@taqueria/node-sdk": "^0.43.5"
 	}
 }

--- a/taqueria-plugin-octez-client/package.json
+++ b/taqueria-plugin-octez-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-octez-client",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A taqueria plugin for utilizing octez-client",
 	"targets": {
 		"default": {
@@ -41,7 +41,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-octez-client/package.json
+++ b/taqueria-plugin-octez-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-octez-client",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A taqueria plugin for utilizing octez-client",
 	"targets": {
 		"default": {
@@ -41,7 +41,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-smartpy-legacy/package.json
+++ b/taqueria-plugin-smartpy-legacy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-smartpy-legacy",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A taqueria plugin for compiling SmartPy smart contracts using SmartPy v0.16 (legacy syntax).",
 	"targets": {
 		"default": {
@@ -51,7 +51,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-smartpy-legacy/package.json
+++ b/taqueria-plugin-smartpy-legacy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-smartpy-legacy",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A taqueria plugin for compiling SmartPy smart contracts using SmartPy v0.16 (legacy syntax).",
 	"targets": {
 		"default": {
@@ -51,7 +51,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-smartpy/package.json
+++ b/taqueria-plugin-smartpy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-smartpy",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A taqueria plugin used to test and compile smart contracts written in SmartPy.",
 	"main": "index.js",
 	"tag": "next",
@@ -43,7 +43,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-smartpy/package.json
+++ b/taqueria-plugin-smartpy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-smartpy",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A taqueria plugin used to test and compile smart contracts written in SmartPy.",
 	"main": "index.js",
 	"tag": "next",
@@ -43,7 +43,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
 		"fast-glob": "^3.3.1"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-taquito/package.json
+++ b/taqueria-plugin-taquito/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-taquito",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A taqueria plugin for originating smart contracts using Taquito",
 	"targets": {
 		"default": {
@@ -42,7 +42,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.4",
+		"@taqueria/node-sdk": "^0.43.5",
 		"@taquito/michel-codec": "^18.0.0-RC.0",
 		"@taquito/signer": "^18.0.0-RC.0",
 		"@taquito/taquito": "^18.0.0-RC.0",

--- a/taqueria-plugin-taquito/package.json
+++ b/taqueria-plugin-taquito/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-taquito",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A taqueria plugin for originating smart contracts using Taquito",
 	"targets": {
 		"default": {
@@ -42,7 +42,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.43.3",
+		"@taqueria/node-sdk": "^0.43.4",
 		"@taquito/michel-codec": "^18.0.0-RC.0",
 		"@taquito/signer": "^18.0.0-RC.0",
 		"@taquito/taquito": "^18.0.0-RC.0",

--- a/taqueria-protocol/package.json
+++ b/taqueria-protocol/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/protocol",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A TypeScript package which contains types that are to be shared between @taqueria/node-sdk and @taqueria/taqueria.",
 	"main": "index.js",
 	"scripts": {

--- a/taqueria-protocol/package.json
+++ b/taqueria-protocol/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/protocol",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A TypeScript package which contains types that are to be shared between @taqueria/node-sdk and @taqueria/taqueria.",
 	"main": "index.js",
 	"scripts": {

--- a/taqueria-sdk/package.json
+++ b/taqueria-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/node-sdk",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A TypeScript SDK for NodeJS used for Taqueria plugin development.",
 	"main": "./index.js",
 	"source": "./index.ts",
@@ -34,7 +34,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/protocol": "^0.43.3",
+		"@taqueria/protocol": "^0.43.4",
 		"@taquito/signer": "^17.3.1",
 		"@taquito/taquito": "^17.3.1",
 		"@taquito/utils": "^17.3.1",

--- a/taqueria-sdk/package.json
+++ b/taqueria-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/node-sdk",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A TypeScript SDK for NodeJS used for Taqueria plugin development.",
 	"main": "./index.js",
 	"source": "./index.ts",
@@ -34,7 +34,7 @@
 	},
 	"homepage": "https://github.com/pinnacle-labs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/protocol": "^0.43.4",
+		"@taqueria/protocol": "^0.43.5",
 		"@taquito/signer": "^17.3.1",
 		"@taquito/taquito": "^17.3.1",
 		"@taquito/utils": "^17.3.1",

--- a/taqueria-toolkit/package.json
+++ b/taqueria-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/toolkit",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"description": "A TypeScript library for NodeJS to work with Taqueria projects",
 	"source": "./index.ts",
 	"main": "./index.js",
@@ -38,7 +38,7 @@
 		"typescript": "^5.2.2"
 	},
 	"dependencies": {
-		"@taqueria/protocol": "^0.43.3",
+		"@taqueria/protocol": "^0.43.4",
 		"buffer": "^6.0.3",
 		"cross-spawn": "^7.0.3",
 		"yargs": "^17.7.2"

--- a/taqueria-toolkit/package.json
+++ b/taqueria-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/toolkit",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"description": "A TypeScript library for NodeJS to work with Taqueria projects",
 	"source": "./index.ts",
 	"main": "./index.js",
@@ -38,7 +38,7 @@
 		"typescript": "^5.2.2"
 	},
 	"dependencies": {
-		"@taqueria/protocol": "^0.43.4",
+		"@taqueria/protocol": "^0.43.5",
 		"buffer": "^6.0.3",
 		"cross-spawn": "^7.0.3",
 		"yargs": "^17.7.2"

--- a/taqueria-vscode-extension-web-ui/package.json
+++ b/taqueria-vscode-extension-web-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "taqueria-vscode-extension-web-ui",
 	"private": true,
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/taqueria-vscode-extension-web-ui/package.json
+++ b/taqueria-vscode-extension-web-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "taqueria-vscode-extension-web-ui",
 	"private": true,
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Taqueria (by Pinnacle Labs)",
 	"description": "A better way to build on Tezos",
 	"publisher": "PinnacleLabs",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"private": true,
 	"engines": {
 		"vscode": "^1.82.0"
@@ -726,8 +726,8 @@
 	},
 	"dependencies": {
 		"@microsoft/signalr": "^6.0.18",
-		"@taqueria/analytics": "^0.43.4",
-		"@taqueria/protocol": "^0.43.4",
+		"@taqueria/analytics": "^0.43.5",
+		"@taqueria/protocol": "^0.43.5",
 		"cli-table3": "^0.6.3",
 		"comment-json": "^4.2.3",
 		"eventsource": "^2.0.2",

--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Taqueria (by Pinnacle Labs)",
 	"description": "A better way to build on Tezos",
 	"publisher": "PinnacleLabs",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"private": true,
 	"engines": {
 		"vscode": "^1.82.0"
@@ -726,8 +726,8 @@
 	},
 	"dependencies": {
 		"@microsoft/signalr": "^6.0.18",
-		"@taqueria/analytics": "^0.43.3",
-		"@taqueria/protocol": "^0.43.3",
+		"@taqueria/analytics": "^0.43.4",
+		"@taqueria/protocol": "^0.43.4",
 		"cli-table3": "^0.6.3",
 		"comment-json": "^4.2.3",
 		"eventsource": "^2.0.2",

--- a/taqueria-vscode-extension/syntaxes/ligo/jsligo.tmLanguage.json
+++ b/taqueria-vscode-extension/syntaxes/ligo/jsligo.tmLanguage.json
@@ -1,443 +1,444 @@
 {
-  "foldingStartMarker": "{",
-  "foldingStopMarker": "}",
-  "name": "JsLIGO",
-  "scopeName": "source.jsligo",
-  "fileTypes": [ "jsligo" ],
-  "patterns": [
-    { "include": "#string0" },
-    { "include": "#string1" },
-    { "include": "#block_comment" },
-    { "include": "#line_comment" },
-    { "include": "#attribute" },
-    { "include": "#uppercaseidentifier" },
-    { "include": "#macro" },
-    { "include": "#letbinding" },
-    { "include": "#typedefinition" },
-    { "include": "#keywords" },
-    { "include": "#controlkeywords" },
-    { "include": "#numericliterals" },
-    { "include": "#operators" },
-    { "include": "#modulealias" },
-    { "include": "#typeannotation" },
-    { "include": "#typeas" },
-    { "include": "#objectorblock" },
-    { "include": "#parentheses" },
-    { "include": "#case" },
-    { "include": "#ternary" },
-    { "include": "#whenclause" }
-  ],
-  "repository": {
-    "string0": {
-      "name": "string.quoted.double.jsligo",
-      "begin": "\\\"",
-      "end": "\\\"",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": []
-    },
-    "string1": {
-      "name": "string.quoted.double.jsligo",
-      "begin": "`",
-      "end": "`",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": []
-    },
-    "block_comment": {
-      "name": "comment.block.jsligo",
-      "begin": "/\\*",
-      "end": "\\*\\/",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#block_comment" }, { "include": "#attribute" }
-      ]
-    },
-    "line_comment": {
-      "name": "comment.block.jsligo",
-      "begin": "\\/\\/",
-      "end": "$",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [ { "include": "#attribute" } ]
-    },
-    "attribute": {
-      "name": "keyword.control.attribute.jsligo",
-      "match": "(@[a-zA-Z][a-zA-Z0-9_:.@%]*)",
-      "captures": {}
-    },
-    "macro": {
-      "name": "meta.preprocessor.jsligo",
-      "match": "^\\#[a-zA-Z]+",
-      "captures": {}
-    },
-    "letbinding": {
-      "match": "\\b(let|const)\\b\\s*",
-      "captures": { "1": { "name": "keyword.other.jsligo" } }
-    },
-    "keywords": {
-      "match": "\\b(export|import|from|implements|contract_of|parameter_of|function|do|namespace|interface|implements|false|true)\\b",
-      "captures": { "1": { "name": "keyword.other.jsligo" } }
-    },
-    "controlkeywords": {
-      "name": "keyword.control.jsligo",
-      "match": "\\b(switch|if|else|for|of|while|return|break|continue|match)\\b",
-      "captures": {}
-    },
-    "numericliterals": {
-      "name": "constant.numeric.jsligo",
-      "match": "\\b(\\+|\\-)?[0-9]+(n|tz|tez|mutez|)\\b",
-      "captures": {}
-    },
-    "operators": {
-      "name": "keyword.operator.jsligo",
-      "match": "\\b(-|\\+|%|&&|\\|\\||==|!=|<=|>=|<|>|\\*|\\/|=|!|\\*=|\\/=|%=|\\+=|-=)\\b",
-      "captures": {}
-    },
-    "semicolon": { "match": "(;)", "captures": {} },
-    "comma": { "match": "(,)", "captures": {} },
-    "ternary": {
-      "begin": "(\\?)",
-      "end": "(:)",
-      "beginCaptures": { "1": { "name": "keyword.operator.jsligo" } },
-      "endCaptures": { "1": { "name": "keyword.operator.jsligo" } },
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "$self" }
-      ]
-    },
-    "whenclause": {
-      "begin": "\\b(when)\\b",
-      "end": "(:)",
-      "beginCaptures": { "1": { "name": "keyword.control.jsligo" } },
-      "endCaptures": { "1": { "name": "keyword.operator.jsligo" } },
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "$self" }
-      ]
-    },
-    "uppercaseidentifier": {
-      "match": "\\b([A-Z][a-zA-Z0-9_$]*)\\b",
-      "captures": { "1": { "name": "entity.name.type.jsligo" } }
-    },
-    "lowercaseidentifier": {
-      "match": "\\b([a-z$_][a-zA-Z0-9$_]*)\\b",
-      "captures": { "1": { "name": "variable.jsligo" } }
-    },
-    "moduleaccess": {
-      "match": "\\b([A-Z][a-zA-Z0-9_$]*)\\.\\s*\\b([a-zA-Z0-9_$]*)\\b",
-      "captures": {
-        "2": { "name": "variable.jsligo" },
-        "1": { "name": "entity.name.type.jsligo" }
-      }
-    },
-    "modulealias": {
-      "match": "\\b(import)\\b\\s*\\b([A-Z][a-zA-Z0-9_$]*)\\b",
-      "captures": {
-        "2": { "name": "entity.name.type.jsligo" },
-        "1": { "name": "keyword.control.jsligo" }
-      }
-    },
-    "objectorblock": {
-      "begin": "({)",
-      "end": "(})",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#objectpropertyctor" },
-        { "include": "#objectpropertyint" },
-        { "include": "#objectpropertystring" },
-        { "include": "#objectproperty" },
-        { "include": "#comma" },
-        { "include": "$self" }
-      ]
-    },
-    "parentheses": {
-      "begin": "(\\()",
-      "end": "(\\))",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#typefunparam" },
-        { "include": "#comma" },
-        { "include": "$self" }
-      ]
-    },
-    "case": {
-      "begin": "\\b(case|default)\\b",
-      "end": "(:)",
-      "beginCaptures": { "1": { "name": "keyword.control.jsligo" } },
-      "endCaptures": { "1": { "name": "keyword.operator.jsligo" } },
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "$self" }
-      ]
-    },
-    "objectpropertyctor": {
-      "begin": "\\b([A-Z][a-zA-Z0-9_$]*)\\b(?=\\s*:)\\s*(:)",
-      "end": "(?=,|;|})",
-      "beginCaptures": {
-        "2": { "name": "keyword.operator.jsligo" },
-        "1": { "name": "variable.other.enummember.jsligo" }
-      },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "$self" }
-      ]
-    },
-    "objectpropertyint": {
-      "begin": "\\b([0-9]+)\\b(?=\\s*:)\\s*(:)",
-      "end": "(?=,|;|})",
-      "beginCaptures": {
-        "2": { "name": "keyword.operator.jsligo" },
-        "1": { "name": "constant.numeric.jsligo" }
-      },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "$self" }
-      ]
-    },
-    "objectpropertystring": {
-      "begin": "(\\\".*\\\")(?=\\s*:)\\s*(:)",
-      "end": "(?=,|;|})",
-      "beginCaptures": {
-        "2": { "name": "keyword.operator.jsligo" },
-        "1": { "name": "string.quoted.double.jsligo" }
-      },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "$self" }
-      ]
-    },
-    "objectproperty": {
-      "begin": "\\b([a-zA-Z$_][a-zA-Z0-9$_]*)\\b(?=\\s*:)\\s*(:)",
-      "end": "(?=,|;|})",
-      "beginCaptures": {
-        "2": { "name": "keyword.operator.jsligo" },
-        "1": { "name": "variable.jsligo" }
-      },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "$self" }
-      ]
-    },
-    "typebinder": {
-      "begin": "(<)",
-      "end": "(>)",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#typename" }
-      ]
-    },
-    "typedefinition": {
-      "begin": "\\b(type)\\b",
-      "end": "(?=;|}|@|\\b(else|default|case|type|let|const|namespace|interface|export|import|function)\\b)",
-      "beginCaptures": { "1": { "name": "keyword.other.jsligo" } },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#keywords" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typevariant" },
-        { "include": "#typeproduct" },
-        { "include": "#typebinder" },
-        { "include": "#typegeneric" },
-        { "include": "#string0" },
-        { "include": "#string1" }
-      ]
-    },
-    "typeannotation": {
-      "begin": "(:)",
-      "end": "(?=\\)|=>|,|{|}|=|;)",
-      "beginCaptures": { "1": { "name": "keyword.operator.jsligo" } },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#keywords" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typevariant" },
-        { "include": "#typeproduct" },
-        { "include": "#typebinder" },
-        { "include": "#typegeneric" },
-        { "include": "#string0" },
-        { "include": "#string1" }
-      ]
-    },
-    "typeannotationfield": {
-      "begin": "(:)",
-      "end": "(?=,|;|})",
-      "beginCaptures": { "1": { "name": "keyword.operator.jsligo" } },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#keywords" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typevariant" },
-        { "include": "#typeproduct" },
-        { "include": "#typebinder" },
-        { "include": "#typegeneric" },
-        { "include": "#string0" },
-        { "include": "#string1" }
-      ]
-    },
-    "typeas": {
-      "begin": "\\b(as)\\b",
-      "end": "(?=;|%=|\\]|}|\\+=|\\*=|-=|=|/=|,|:|\\b(else|default|case|as)\\b)",
-      "beginCaptures": { "1": { "name": "keyword.other.jsligo" } },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#keywords" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typevariant" },
-        { "include": "#typeproduct" },
-        { "include": "#typebinder" },
-        { "include": "#typegeneric" },
-        { "include": "#string0" },
-        { "include": "#string1" }
-      ]
-    },
-    "typeoperator": {
-      "name": "keyword.operator.jsligo",
-      "match": "(=>|\\.|\\|)",
-      "captures": {}
-    },
-    "typegeneric": {
-      "begin": "(<)",
-      "end": "(>)",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#comma" },
-        { "include": "#keywords" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typevariant" },
-        { "include": "#typeproduct" },
-        { "include": "#typebinder" },
-        { "include": "#typegeneric" },
-        { "include": "#string0" },
-        { "include": "#string1" }
-      ]
-    },
-    "typefunparam": {
-      "match": "\\b([a-zA-Z$_][a-zA-Z0-9$_]*)\\b\\s*(?=:)",
-      "captures": { "1": { "name": "variable.jsligo" } }
-    },
-    "typename": {
-      "name": "entity.name.type.jsligo",
-      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
-      "captures": {}
-    },
-    "typeparentheses": {
-      "begin": "(\\()",
-      "end": "(\\))",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#typefunparam" },
-        { "include": "#typeannotation" },
-        { "include": "#comma" },
-        { "include": "#keywords" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typevariant" },
-        { "include": "#typeproduct" },
-        { "include": "#typebinder" },
-        { "include": "#typegeneric" },
-        { "include": "#string0" },
-        { "include": "#string1" }
-      ]
-    },
-    "typeint": {
-      "name": "constant.numeric.jsligo",
-      "match": "\\b([0-9]+)\\b",
-      "captures": {}
-    },
-    "typevariant": {
-      "begin": "(\\[)",
-      "end": "(\\])",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#comma" },
-        { "include": "#keywords" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typevariant" },
-        { "include": "#typeproduct" },
-        { "include": "#typebinder" },
-        { "include": "#typegeneric" },
-        { "include": "#string0" },
-        { "include": "#string1" }
-      ]
-    },
-    "typeproduct": {
-      "begin": "({)",
-      "end": "(})",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#lowercaseidentifier" },
-        { "include": "#typeannotationfield" },
-        { "include": "#comma" }
-      ]
-    }
-  }
+	"foldingStartMarker": "{",
+	"foldingStopMarker": "}",
+	"name": "JsLIGO",
+	"scopeName": "source.jsligo",
+	"fileTypes": ["jsligo"],
+	"patterns": [
+		{ "include": "#string0" },
+		{ "include": "#string1" },
+		{ "include": "#block_comment" },
+		{ "include": "#line_comment" },
+		{ "include": "#attribute" },
+		{ "include": "#uppercaseidentifier" },
+		{ "include": "#macro" },
+		{ "include": "#letbinding" },
+		{ "include": "#typedefinition" },
+		{ "include": "#keywords" },
+		{ "include": "#controlkeywords" },
+		{ "include": "#numericliterals" },
+		{ "include": "#operators" },
+		{ "include": "#modulealias" },
+		{ "include": "#typeannotation" },
+		{ "include": "#typeas" },
+		{ "include": "#objectorblock" },
+		{ "include": "#parentheses" },
+		{ "include": "#case" },
+		{ "include": "#ternary" },
+		{ "include": "#whenclause" }
+	],
+	"repository": {
+		"string0": {
+			"name": "string.quoted.double.jsligo",
+			"begin": "\\\"",
+			"end": "\\\"",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": []
+		},
+		"string1": {
+			"name": "string.quoted.double.jsligo",
+			"begin": "`",
+			"end": "`",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": []
+		},
+		"block_comment": {
+			"name": "comment.block.jsligo",
+			"begin": "/\\*",
+			"end": "\\*\\/",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#block_comment" },
+				{ "include": "#attribute" }
+			]
+		},
+		"line_comment": {
+			"name": "comment.block.jsligo",
+			"begin": "\\/\\/",
+			"end": "$",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [{ "include": "#attribute" }]
+		},
+		"attribute": {
+			"name": "keyword.control.attribute.jsligo",
+			"match": "(@[a-zA-Z][a-zA-Z0-9_:.@%]*)",
+			"captures": {}
+		},
+		"macro": {
+			"name": "meta.preprocessor.jsligo",
+			"match": "^\\#[a-zA-Z]+",
+			"captures": {}
+		},
+		"letbinding": {
+			"match": "\\b(let|const)\\b\\s*",
+			"captures": { "1": { "name": "keyword.other.jsligo" } }
+		},
+		"keywords": {
+			"match": "\\b(export|import|from|implements|contract_of|parameter_of|function|do|namespace|interface|implements|false|true)\\b",
+			"captures": { "1": { "name": "keyword.other.jsligo" } }
+		},
+		"controlkeywords": {
+			"name": "keyword.control.jsligo",
+			"match": "\\b(switch|if|else|for|of|while|return|break|continue|match)\\b",
+			"captures": {}
+		},
+		"numericliterals": {
+			"name": "constant.numeric.jsligo",
+			"match": "\\b(\\+|\\-)?[0-9]+(n|tz|tez|mutez|)\\b",
+			"captures": {}
+		},
+		"operators": {
+			"name": "keyword.operator.jsligo",
+			"match": "\\b(-|\\+|%|&&|\\|\\||==|!=|<=|>=|<|>|\\*|\\/|=|!|\\*=|\\/=|%=|\\+=|-=)\\b",
+			"captures": {}
+		},
+		"semicolon": { "match": "(;)", "captures": {} },
+		"comma": { "match": "(,)", "captures": {} },
+		"ternary": {
+			"begin": "(\\?)",
+			"end": "(:)",
+			"beginCaptures": { "1": { "name": "keyword.operator.jsligo" } },
+			"endCaptures": { "1": { "name": "keyword.operator.jsligo" } },
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "$self" }
+			]
+		},
+		"whenclause": {
+			"begin": "\\b(when)\\b",
+			"end": "(:)",
+			"beginCaptures": { "1": { "name": "keyword.control.jsligo" } },
+			"endCaptures": { "1": { "name": "keyword.operator.jsligo" } },
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "$self" }
+			]
+		},
+		"uppercaseidentifier": {
+			"match": "\\b([A-Z][a-zA-Z0-9_$]*)\\b",
+			"captures": { "1": { "name": "entity.name.type.jsligo" } }
+		},
+		"lowercaseidentifier": {
+			"match": "\\b([a-z$_][a-zA-Z0-9$_]*)\\b",
+			"captures": { "1": { "name": "variable.jsligo" } }
+		},
+		"moduleaccess": {
+			"match": "\\b([A-Z][a-zA-Z0-9_$]*)\\.\\s*\\b([a-zA-Z0-9_$]*)\\b",
+			"captures": {
+				"2": { "name": "variable.jsligo" },
+				"1": { "name": "entity.name.type.jsligo" }
+			}
+		},
+		"modulealias": {
+			"match": "\\b(import)\\b\\s*\\b([A-Z][a-zA-Z0-9_$]*)\\b",
+			"captures": {
+				"2": { "name": "entity.name.type.jsligo" },
+				"1": { "name": "keyword.control.jsligo" }
+			}
+		},
+		"objectorblock": {
+			"begin": "({)",
+			"end": "(})",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#objectpropertyctor" },
+				{ "include": "#objectpropertyint" },
+				{ "include": "#objectpropertystring" },
+				{ "include": "#objectproperty" },
+				{ "include": "#comma" },
+				{ "include": "$self" }
+			]
+		},
+		"parentheses": {
+			"begin": "(\\()",
+			"end": "(\\))",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#typefunparam" },
+				{ "include": "#comma" },
+				{ "include": "$self" }
+			]
+		},
+		"case": {
+			"begin": "\\b(case|default)\\b",
+			"end": "(:)",
+			"beginCaptures": { "1": { "name": "keyword.control.jsligo" } },
+			"endCaptures": { "1": { "name": "keyword.operator.jsligo" } },
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "$self" }
+			]
+		},
+		"objectpropertyctor": {
+			"begin": "\\b([A-Z][a-zA-Z0-9_$]*)\\b(?=\\s*:)\\s*(:)",
+			"end": "(?=,|;|})",
+			"beginCaptures": {
+				"2": { "name": "keyword.operator.jsligo" },
+				"1": { "name": "variable.other.enummember.jsligo" }
+			},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "$self" }
+			]
+		},
+		"objectpropertyint": {
+			"begin": "\\b([0-9]+)\\b(?=\\s*:)\\s*(:)",
+			"end": "(?=,|;|})",
+			"beginCaptures": {
+				"2": { "name": "keyword.operator.jsligo" },
+				"1": { "name": "constant.numeric.jsligo" }
+			},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "$self" }
+			]
+		},
+		"objectpropertystring": {
+			"begin": "(\\\".*\\\")(?=\\s*:)\\s*(:)",
+			"end": "(?=,|;|})",
+			"beginCaptures": {
+				"2": { "name": "keyword.operator.jsligo" },
+				"1": { "name": "string.quoted.double.jsligo" }
+			},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "$self" }
+			]
+		},
+		"objectproperty": {
+			"begin": "\\b([a-zA-Z$_][a-zA-Z0-9$_]*)\\b(?=\\s*:)\\s*(:)",
+			"end": "(?=,|;|})",
+			"beginCaptures": {
+				"2": { "name": "keyword.operator.jsligo" },
+				"1": { "name": "variable.jsligo" }
+			},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "$self" }
+			]
+		},
+		"typebinder": {
+			"begin": "(<)",
+			"end": "(>)",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#typename" }
+			]
+		},
+		"typedefinition": {
+			"begin": "\\b(type)\\b",
+			"end": "(?=;|}|@|\\b(else|default|case|type|let|const|namespace|interface|export|import|function)\\b)",
+			"beginCaptures": { "1": { "name": "keyword.other.jsligo" } },
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#keywords" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typevariant" },
+				{ "include": "#typeproduct" },
+				{ "include": "#typebinder" },
+				{ "include": "#typegeneric" },
+				{ "include": "#string0" },
+				{ "include": "#string1" }
+			]
+		},
+		"typeannotation": {
+			"begin": "(:)",
+			"end": "(?=\\)|=>|,|{|}|=|;)",
+			"beginCaptures": { "1": { "name": "keyword.operator.jsligo" } },
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#keywords" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typevariant" },
+				{ "include": "#typeproduct" },
+				{ "include": "#typebinder" },
+				{ "include": "#typegeneric" },
+				{ "include": "#string0" },
+				{ "include": "#string1" }
+			]
+		},
+		"typeannotationfield": {
+			"begin": "(:)",
+			"end": "(?=,|;|})",
+			"beginCaptures": { "1": { "name": "keyword.operator.jsligo" } },
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#keywords" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typevariant" },
+				{ "include": "#typeproduct" },
+				{ "include": "#typebinder" },
+				{ "include": "#typegeneric" },
+				{ "include": "#string0" },
+				{ "include": "#string1" }
+			]
+		},
+		"typeas": {
+			"begin": "\\b(as)\\b",
+			"end": "(?=;|%=|\\]|}|\\+=|\\*=|-=|=|/=|,|:|\\b(else|default|case|as)\\b)",
+			"beginCaptures": { "1": { "name": "keyword.other.jsligo" } },
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#keywords" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typevariant" },
+				{ "include": "#typeproduct" },
+				{ "include": "#typebinder" },
+				{ "include": "#typegeneric" },
+				{ "include": "#string0" },
+				{ "include": "#string1" }
+			]
+		},
+		"typeoperator": {
+			"name": "keyword.operator.jsligo",
+			"match": "(=>|\\.|\\|)",
+			"captures": {}
+		},
+		"typegeneric": {
+			"begin": "(<)",
+			"end": "(>)",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#comma" },
+				{ "include": "#keywords" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typevariant" },
+				{ "include": "#typeproduct" },
+				{ "include": "#typebinder" },
+				{ "include": "#typegeneric" },
+				{ "include": "#string0" },
+				{ "include": "#string1" }
+			]
+		},
+		"typefunparam": {
+			"match": "\\b([a-zA-Z$_][a-zA-Z0-9$_]*)\\b\\s*(?=:)",
+			"captures": { "1": { "name": "variable.jsligo" } }
+		},
+		"typename": {
+			"name": "entity.name.type.jsligo",
+			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
+			"captures": {}
+		},
+		"typeparentheses": {
+			"begin": "(\\()",
+			"end": "(\\))",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#typefunparam" },
+				{ "include": "#typeannotation" },
+				{ "include": "#comma" },
+				{ "include": "#keywords" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typevariant" },
+				{ "include": "#typeproduct" },
+				{ "include": "#typebinder" },
+				{ "include": "#typegeneric" },
+				{ "include": "#string0" },
+				{ "include": "#string1" }
+			]
+		},
+		"typeint": {
+			"name": "constant.numeric.jsligo",
+			"match": "\\b([0-9]+)\\b",
+			"captures": {}
+		},
+		"typevariant": {
+			"begin": "(\\[)",
+			"end": "(\\])",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#comma" },
+				{ "include": "#keywords" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typevariant" },
+				{ "include": "#typeproduct" },
+				{ "include": "#typebinder" },
+				{ "include": "#typegeneric" },
+				{ "include": "#string0" },
+				{ "include": "#string1" }
+			]
+		},
+		"typeproduct": {
+			"begin": "({)",
+			"end": "(})",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#lowercaseidentifier" },
+				{ "include": "#typeannotationfield" },
+				{ "include": "#comma" }
+			]
+		}
+	}
 }

--- a/taqueria-vscode-extension/syntaxes/ligo/mligo.tmLanguage.json
+++ b/taqueria-vscode-extension/syntaxes/ligo/mligo.tmLanguage.json
@@ -1,209 +1,209 @@
 {
-  "name": "mligo",
-  "scopeName": "source.mligo",
-  "fileTypes": [ "mligo" ],
-  "patterns": [
-    { "include": "#string0" },
-    { "include": "#block_comment" },
-    { "include": "#line_comment" },
-    { "include": "#uppercaseidentifier" },
-    { "include": "#attribute" },
-    { "include": "#macro" },
-    { "include": "#lambda" },
-    { "include": "#typedefinition" },
-    { "include": "#controlkeywords" },
-    { "include": "#keywords" },
-    { "include": "#numericliterals" },
-    { "include": "#operators" },
-    { "include": "#typeannotation" }
-  ],
-  "repository": {
-    "string0": {
-      "name": "string.quoted.double.mligo",
-      "begin": "\\\"",
-      "end": "\\\"",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": []
-    },
-    "block_comment": {
-      "name": "comment.block.mligo",
-      "begin": "\\(\\*",
-      "end": "\\*\\)",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [ { "include": "#block_comment" } ]
-    },
-    "line_comment": {
-      "name": "comment.block.mligo",
-      "begin": "\\/\\/",
-      "end": "$",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": []
-    },
-    "attribute": {
-      "name": "keyword.control.attribute.mligo",
-      "match": "\\[@[^\\]]*\\]",
-      "captures": {}
-    },
-    "macro": {
-      "name": "meta.preprocessor.mligo",
-      "match": "^\\#[a-zA-Z]+",
-      "captures": {}
-    },
-    "controlkeywords": {
-      "name": "keyword.control.mligo",
-      "match": "\\b(match|with|if|then|else|assert|failwith|begin|for|upto|downto|do|while|done)\\b",
-      "captures": {}
-    },
-    "keywords": {
-      "name": "keyword.other.mligo",
-      "match": "\\b(struct|end|let|in|mut|rec|contract_of|parameter_of|module|sig|val|include|false|true)\\b",
-      "captures": {}
-    },
-    "numericliterals": {
-      "name": "constant.numeric.mligo",
-      "match": "\\b(\\+|\\-)?[0-9]+(n|tz|tez|mutez|)\\b",
-      "captures": {}
-    },
-    "operators": {
-      "name": "keyword.operator.mligo",
-      "match": "::|\\-|\\+|\\b(mod|land|lor|lxor|lsl|lsr)\\b|&&|\\|\\||>|<>|<=|=>|<|>|\\|>|->|:=|\\^|\\*|\\+=|-=|\\*=|/=|\\|=",
-      "captures": {}
-    },
-    "semicolon": { "match": "(;)", "captures": {} },
-    "ofkeyword": {
-      "match": "\\b(of)\\b",
-      "captures": { "1": { "name": "keyword.other.mligo" } }
-    },
-    "lambda": {
-      "begin": "\\b(fun)\\b",
-      "end": "(->)",
-      "beginCaptures": { "1": { "name": "keyword.other.mligo" } },
-      "endCaptures": { "1": { "name": "keyword.operator.mligo" } },
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#typeannotationlambda" }
-      ]
-    },
-    "uppercaseidentifier": {
-      "match": "\\b([A-Z][a-zA-Z0-9_$]*)\\b",
-      "captures": { "1": { "name": "entity.name.type.mligo" } }
-    },
-    "lowercaseidentifier": {
-      "match": "\\b([a-z$_][a-zA-Z0-9$_]*)\\b",
-      "captures": { "1": { "name": "variable.mligo" } }
-    },
-    "typedefinition": {
-      "begin": "\\b(type)\\b",
-      "end": "(?=^#|\\[@|\\b(let|in|type|end|module|sig|val)\\b|\\))",
-      "beginCaptures": { "1": { "name": "keyword.other.mligo" } },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#ofkeyword" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typevar" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typeproduct" },
-        { "include": "#string0" }
-      ]
-    },
-    "typeannotation": {
-      "begin": "(:)",
-      "end": "(?=\\)|=|;|}|^#|\\[@|\\b(let|in|type|end|module|sig|val|end)\\b)",
-      "beginCaptures": { "1": { "name": "keyword.operator.mligo" } },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#ofkeyword" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typevar" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typeproduct" },
-        { "include": "#string0" }
-      ]
-    },
-    "typeannotationlambda": {
-      "begin": "(:)",
-      "end": "(?=\\)|=|;|}|->)",
-      "beginCaptures": { "1": { "name": "keyword.operator.mligo" } },
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#ofkeyword" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typevar" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typeproduct" },
-        { "include": "#string0" }
-      ]
-    },
-    "typeoperator": {
-      "name": "keyword.operator.mligo",
-      "match": "(->|\\.|\\*|\\|)",
-      "captures": {}
-    },
-    "typename": {
-      "name": "entity.name.type.mligo",
-      "match": "\\b([a-z_][a-zA-Z0-9_]*)\\b",
-      "captures": {}
-    },
-    "typevar": {
-      "name": "variable.other.type.mligo",
-      "match": "'\\b([a-z_][a-zA-Z0-9_]*)\\b",
-      "captures": {}
-    },
-    "typeparentheses": {
-      "begin": "(\\()",
-      "end": "(\\))",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#ofkeyword" },
-        { "include": "#typeoperator" },
-        { "include": "#typename" },
-        { "include": "#typevar" },
-        { "include": "#typeparentheses" },
-        { "include": "#typeint" },
-        { "include": "#typeproduct" },
-        { "include": "#string0" }
-      ]
-    },
-    "typeint": {
-      "name": "constant.numeric.mligo",
-      "match": "\\b([0-9]+)\\b",
-      "captures": {}
-    },
-    "typeproduct": {
-      "begin": "({)",
-      "end": "(})",
-      "beginCaptures": {},
-      "endCaptures": {},
-      "patterns": [
-        { "include": "#line_comment" },
-        { "include": "#block_comment" },
-        { "include": "#uppercaseidentifier" },
-        { "include": "#typeannotation" },
-        { "include": "#semicolon" }
-      ]
-    }
-  }
+	"name": "mligo",
+	"scopeName": "source.mligo",
+	"fileTypes": ["mligo"],
+	"patterns": [
+		{ "include": "#string0" },
+		{ "include": "#block_comment" },
+		{ "include": "#line_comment" },
+		{ "include": "#uppercaseidentifier" },
+		{ "include": "#attribute" },
+		{ "include": "#macro" },
+		{ "include": "#lambda" },
+		{ "include": "#typedefinition" },
+		{ "include": "#controlkeywords" },
+		{ "include": "#keywords" },
+		{ "include": "#numericliterals" },
+		{ "include": "#operators" },
+		{ "include": "#typeannotation" }
+	],
+	"repository": {
+		"string0": {
+			"name": "string.quoted.double.mligo",
+			"begin": "\\\"",
+			"end": "\\\"",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": []
+		},
+		"block_comment": {
+			"name": "comment.block.mligo",
+			"begin": "\\(\\*",
+			"end": "\\*\\)",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [{ "include": "#block_comment" }]
+		},
+		"line_comment": {
+			"name": "comment.block.mligo",
+			"begin": "\\/\\/",
+			"end": "$",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": []
+		},
+		"attribute": {
+			"name": "keyword.control.attribute.mligo",
+			"match": "\\[@[^\\]]*\\]",
+			"captures": {}
+		},
+		"macro": {
+			"name": "meta.preprocessor.mligo",
+			"match": "^\\#[a-zA-Z]+",
+			"captures": {}
+		},
+		"controlkeywords": {
+			"name": "keyword.control.mligo",
+			"match": "\\b(match|with|if|then|else|assert|failwith|begin|for|upto|downto|do|while|done)\\b",
+			"captures": {}
+		},
+		"keywords": {
+			"name": "keyword.other.mligo",
+			"match": "\\b(struct|end|let|in|mut|rec|contract_of|parameter_of|module|sig|val|include|false|true)\\b",
+			"captures": {}
+		},
+		"numericliterals": {
+			"name": "constant.numeric.mligo",
+			"match": "\\b(\\+|\\-)?[0-9]+(n|tz|tez|mutez|)\\b",
+			"captures": {}
+		},
+		"operators": {
+			"name": "keyword.operator.mligo",
+			"match": "::|\\-|\\+|\\b(mod|land|lor|lxor|lsl|lsr)\\b|&&|\\|\\||>|<>|<=|=>|<|>|\\|>|->|:=|\\^|\\*|\\+=|-=|\\*=|/=|\\|=",
+			"captures": {}
+		},
+		"semicolon": { "match": "(;)", "captures": {} },
+		"ofkeyword": {
+			"match": "\\b(of)\\b",
+			"captures": { "1": { "name": "keyword.other.mligo" } }
+		},
+		"lambda": {
+			"begin": "\\b(fun)\\b",
+			"end": "(->)",
+			"beginCaptures": { "1": { "name": "keyword.other.mligo" } },
+			"endCaptures": { "1": { "name": "keyword.operator.mligo" } },
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#typeannotationlambda" }
+			]
+		},
+		"uppercaseidentifier": {
+			"match": "\\b([A-Z][a-zA-Z0-9_$]*)\\b",
+			"captures": { "1": { "name": "entity.name.type.mligo" } }
+		},
+		"lowercaseidentifier": {
+			"match": "\\b([a-z$_][a-zA-Z0-9$_]*)\\b",
+			"captures": { "1": { "name": "variable.mligo" } }
+		},
+		"typedefinition": {
+			"begin": "\\b(type)\\b",
+			"end": "(?=^#|\\[@|\\b(let|in|type|end|module|sig|val)\\b|\\))",
+			"beginCaptures": { "1": { "name": "keyword.other.mligo" } },
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#ofkeyword" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typevar" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typeproduct" },
+				{ "include": "#string0" }
+			]
+		},
+		"typeannotation": {
+			"begin": "(:)",
+			"end": "(?=\\)|=|;|}|^#|\\[@|\\b(let|in|type|end|module|sig|val|end)\\b)",
+			"beginCaptures": { "1": { "name": "keyword.operator.mligo" } },
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#ofkeyword" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typevar" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typeproduct" },
+				{ "include": "#string0" }
+			]
+		},
+		"typeannotationlambda": {
+			"begin": "(:)",
+			"end": "(?=\\)|=|;|}|->)",
+			"beginCaptures": { "1": { "name": "keyword.operator.mligo" } },
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#ofkeyword" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typevar" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typeproduct" },
+				{ "include": "#string0" }
+			]
+		},
+		"typeoperator": {
+			"name": "keyword.operator.mligo",
+			"match": "(->|\\.|\\*|\\|)",
+			"captures": {}
+		},
+		"typename": {
+			"name": "entity.name.type.mligo",
+			"match": "\\b([a-z_][a-zA-Z0-9_]*)\\b",
+			"captures": {}
+		},
+		"typevar": {
+			"name": "variable.other.type.mligo",
+			"match": "'\\b([a-z_][a-zA-Z0-9_]*)\\b",
+			"captures": {}
+		},
+		"typeparentheses": {
+			"begin": "(\\()",
+			"end": "(\\))",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#ofkeyword" },
+				{ "include": "#typeoperator" },
+				{ "include": "#typename" },
+				{ "include": "#typevar" },
+				{ "include": "#typeparentheses" },
+				{ "include": "#typeint" },
+				{ "include": "#typeproduct" },
+				{ "include": "#string0" }
+			]
+		},
+		"typeint": {
+			"name": "constant.numeric.mligo",
+			"match": "\\b([0-9]+)\\b",
+			"captures": {}
+		},
+		"typeproduct": {
+			"begin": "({)",
+			"end": "(})",
+			"beginCaptures": {},
+			"endCaptures": {},
+			"patterns": [
+				{ "include": "#line_comment" },
+				{ "include": "#block_comment" },
+				{ "include": "#uppercaseidentifier" },
+				{ "include": "#typeannotation" },
+				{ "include": "#semicolon" }
+			]
+		}
+	}
 }

--- a/tests/e2e/cli-scaffolding-tests.spec.ts
+++ b/tests/e2e/cli-scaffolding-tests.spec.ts
@@ -21,7 +21,6 @@ describe('E2E Testing for taqueria scaffolding initialization,', () => {
 			'scaffold-test/app',
 			'scaffold-test/node_modules',
 			'scaffold-test/contracts',
-			'scaffold-test/artifacts/hello-tacos.tz',
 		];
 
 		// Get the path to the `ls` command

--- a/tests/e2e/taquito-plugin-e2e-tests.spec.ts
+++ b/tests/e2e/taquito-plugin-e2e-tests.spec.ts
@@ -234,12 +234,14 @@ describe('Taquito Plugin E2E testing for Taqueria CLI', () => {
 			const increment_tz_file = await (await exec('cat e2e/data/michelson-data/increment.tz')).stdout;
 			await writeFile('./test-project/artifacts/increment.tz', increment_tz_file);
 
-			const { stdout: stdout2, stderr } = await execute(
+			const deployResult = await execute(
 				'taq',
 				'deploy hello-tacos.tz --storage anyContract.storage.tz -e testing',
 				'./test-project',
 			);
 
+			// console.log(deployResult)
+			const { stdout: stdout2, stderr } = deployResult;
 			const result = stdout2.join('\n');
 			expect(result).toMatch(/| Contract\s+| Address\s+| Alias\s+| Balance In Mutez\s+| Destination/);
 			expect(result).toMatch(/hello-tacos.tz\s+| KT[^\|]+| hello-tacos\s+| 0\s+| .+rpc\.ghostnet\.teztnets\.xyz/m);

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/tests",
-	"version": "0.43.4",
+	"version": "0.43.5",
 	"type": "module",
 	"private": true,
 	"description": "This is Taqueria testing project includes unit, integration and e2e tests",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/tests",
-	"version": "0.43.3",
+	"version": "0.43.4",
 	"type": "module",
 	"private": true,
 	"description": "This is Taqueria testing project includes unit, integration and e2e tests",


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

`ligo` binary available globally can be faster to load and run. This PR looks into $PATH and if it finds it - uses it instead of the docker image

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [x] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [x] 🪸 Required updates to scaffolds have been made
- [x] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

This PR introduces a new function `baseDriverCmd` that tries to resolve a ligo binary from $PATH and uses it instead of the docker run command

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [ ] 🛠️ Fix ➾
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
